### PR TITLE
Improve per-element span semantics 

### DIFF
--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ElementTracerMap.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ElementTracerMap.scala
@@ -1,0 +1,67 @@
+package io.kaizensolutions.trace4cats.zio.extras
+
+import io.janstenpickle.trace4cats.model.{SpanId, TraceId}
+import zio.*
+
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+import ElementTracerMap.SpannedCallback
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * ElementTracerMap is responsible for holding the outermost span open of each
+ * element in a stream in order to prevent premature submissions of spans to the
+ * completer. It uses two promises:
+ *   - A promise to extract the span from its lifecycle
+ *   - A promise that is used to signal that the span is ready to be closed and
+ *     submitted
+ *
+ * @param openScope
+ * @param spanCloseMap
+ */
+final case class ElementTracerMap(
+  openScope: ZScope.Open[Exit[Any, Any]],
+  spanCloseMap: ConcurrentMap[(SpanId, TraceId), Promise[Nothing, Unit]]
+) {
+  def traceElement[A](element: A, callback: SpannedCallback): UIO[Spanned[A]] =
+    for {
+      waitSpan  <- Promise.make[Nothing, ZSpan]
+      closeSpan <- Promise.make[Nothing, Unit]
+      _ <- callback { span =>
+             val trackElement = ZIO.succeed(spanCloseMap.put((span.context.spanId, span.context.traceId), closeSpan))
+             ZIO.uninterruptible(waitSpan.succeed(span) *> trackElement) *> closeSpan.await
+           }.forkIn(openScope.scope)
+      span         <- waitSpan.await
+      removeElement = ZIO.succeed(spanCloseMap.remove((span.context.spanId, span.context.traceId)))
+    } yield Spanned(
+      span = span,
+      closeSpan = closeSpan.succeed(()).zip(removeElement),
+      value = element
+    )
+
+  def cleanup(exit: Exit[Nothing, Any], strategy: ExecutionStrategy = ExecutionStrategy.Sequential): UIO[Boolean] = {
+    def completePromise(p: Promise[Nothing, Unit]): UIO[Boolean] = exit match {
+      case Exit.Success(_)     => p.succeed(())
+      case Exit.Failure(cause) => p.halt(cause)
+    }
+
+    strategy match {
+      case ExecutionStrategy.Sequential =>
+        ZIO.foreach_(spanCloseMap.values().asScala)(completePromise) *> openScope.close(exit)
+
+      case ExecutionStrategy.Parallel =>
+        ZIO.foreachPar_(spanCloseMap.values().asScala)(completePromise) *> openScope.close(exit)
+
+      case ExecutionStrategy.ParallelN(n) =>
+        ZIO.foreachParN_(n)(spanCloseMap.values().asScala)(completePromise) *> openScope.close(exit)
+    }
+  }
+}
+object ElementTracerMap {
+  type SpannedCallback = (ZSpan => UIO[Any]) => UIO[Any]
+
+  def make(openScope: ZScope.Open[Exit[Any, Any]], capacity: Int = 128): UIO[ElementTracerMap] =
+    ZIO
+      .succeed(new ConcurrentHashMap[(SpanId, TraceId), Promise[Nothing, Unit]](capacity))
+      .map(ElementTracerMap(openScope, _))
+}

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/Spanned.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/Spanned.scala
@@ -1,6 +1,6 @@
 package io.kaizensolutions.trace4cats.zio.extras
 
-import zio.{Has, ZIO}
+import zio.{Has, UIO, ZIO}
 
 /**
  * Attaches a span to an element. This is used to trace each element in a
@@ -9,12 +9,16 @@ import zio.{Has, ZIO}
  *   is the span that is attached to the element.
  * @param value
  *   is the element that is being traced.
+ *
+ * @param closeSpan
+ *   is the handle to close the outer span
+ *
  * @tparam A
  *   is the element type that is being traced.
  */
-final case class Spanned[+A](span: ZSpan, value: A) {
+final case class Spanned[+A](span: ZSpan, closeSpan: UIO[Any], value: A) {
   def map[B](f: A => B): Spanned[B] =
-    Spanned(span, f(value))
+    copy(value = f(value))
 
   def mapZIO[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, Spanned[B]] =
     f(value).map(b => copy(value = b))

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/package.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/package.scala
@@ -25,13 +25,13 @@ package object extras {
 
   implicit class ZTracerStreamOps[R <: Has[?], E, A](val s: ZStream[R, E, A]) extends AnyVal {
     def traceEachElement(
-      name: String,
+      extractName: A => String,
       kind: SpanKind = SpanKind.Internal,
       errorHandler: ErrorHandler = ErrorHandler.empty
     )(extractHeaders: A => TraceHeaders): ZStream[R & Has[ZTracer], E, Spanned[A]] =
       ZStream
         .service[ZTracer]
-        .flatMap(_.traceEachElement(extractHeaders, name, kind, errorHandler)(s))
+        .flatMap(_.traceEachElement(extractHeaders, extractName, kind, errorHandler)(s))
   }
 
   implicit class ZTracerStreamSpannedOps[-R <: Has[?], +E, +A](val s: ZStream[R, E, Spanned[A]]) extends AnyVal {

--- a/fs2-kafka-examples/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/examples/TracedKafkaProducerExample.scala
+++ b/fs2-kafka-examples/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/examples/TracedKafkaProducerExample.scala
@@ -1,14 +1,14 @@
 package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka.examples
 
+import fs2.kafka.*
 import fs2.{Pipe, Stream}
-import fs2.kafka.{KafkaProducer, ProducerRecord, ProducerRecords, ProducerResult, ProducerSettings}
+import io.janstenpickle.trace4cats.model.TraceProcess
 import io.kaizensolutions.trace4cats.zio.extras.*
+import io.kaizensolutions.trace4cats.zio.extras.fs2.kafka.KafkaProducerTracer
 import zio.*
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.interop.catz.*
-import io.janstenpickle.trace4cats.model.TraceProcess
-import io.kaizensolutions.trace4cats.zio.extras.fs2.kafka.KafkaProducerTracer
 
 object TracedKafkaProducerExample extends App {
   type Effect[A] = RIO[Has[ZTracer] & Clock & Blocking, A]

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaProducerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaProducerTracer.scala
@@ -3,12 +3,13 @@ package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka
 import cats.data.NonEmptyList
 import fs2.kafka.*
 import io.janstenpickle.trace4cats.ToHeaders
-import io.janstenpickle.trace4cats.model.AttributeValue
+import io.janstenpickle.trace4cats.model.{AttributeValue, SpanKind}
 import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
 import org.apache.kafka.common.{Metric, MetricName}
-import zio.ZIO
+import zio.ZManaged.ReleaseMap
 import zio.blocking.Blocking
 import zio.clock.Clock
+import zio.{Exit, ZIO}
 
 object KafkaProducerTracer {
   def traceMetrics[R <: Clock & Blocking, E <: Throwable, K, V](
@@ -36,42 +37,56 @@ object KafkaProducerTracer {
         tracedProduce[R, E, K, V, P](tracer, underlying, headers)(records)
     }
 
+  // Note: We unwrap the ZManaged as we need to hold the span open until we receive an ack from the broker which is represented by the inner effect
   private def tracedProduce[R <: Clock & Blocking, E <: Throwable, K, V, P](
     tracer: ZTracer,
     underlying: KafkaProducer[ZIO[R, E, *], K, V],
     headers: ToHeaders
-  )(records: ProducerRecords[P, K, V]): ZIO[R, E, ZIO[R, E, ProducerResult[P, K, V]]] =
-    tracer.withSpan("kafka-producer-send-buffer") { span =>
-      tracer.extractHeaders(headers).flatMap { traceHeaders =>
-        val enrichSpanWithTopics =
-          if (span.isSampled)
-            NonEmptyList
-              .fromList(records.records.map(_.topic).toList)
-              .fold(ifEmpty = ZIO.unit)(topics => span.put("topics", AttributeValue.StringList(topics)))
-          else ZIO.unit
+  )(records: ProducerRecords[P, K, V]): ZIO[R, E, ZIO[R, E, ProducerResult[P, K, V]]] = {
+    ReleaseMap.make
+      .flatMap(rlsMap =>
+        tracer
+          .spanManaged("kafka-producer-send-buffer", kind = SpanKind.Producer)
+          .zio
+          .provide(((), rlsMap))
+      )
+      .flatMap { case (finalizer, span) =>
+        tracer
+          .extractHeaders(headers)
+          .flatMap { traceHeaders =>
+            val enrichSpanWithTopics =
+              if (span.isSampled)
+                NonEmptyList
+                  .fromList(records.records.map(_.topic).toList)
+                  .fold(ifEmpty = ZIO.unit)(topics => span.put("topics", AttributeValue.StringList(topics)))
+              else ZIO.unit
 
-        val kafkaTraceHeaders =
-          Headers.fromIterable(traceHeaders.values.map { case (k, v) => Header(k.toString, v) })
-        val recordsWithTraceHeaders =
-          records.records.map(record => record.withHeaders(record.headers.concat(kafkaTraceHeaders)))
+            val kafkaTraceHeaders =
+              Headers.fromIterable(traceHeaders.values.map { case (k, v) => Header(k.toString, v) })
+            val recordsWithTraceHeaders =
+              records.records.map(record => record.withHeaders(record.headers.concat(kafkaTraceHeaders)))
 
-        val sendToProducerBuffer =
-          enrichSpanWithTopics *> underlying.produce(ProducerRecords(recordsWithTraceHeaders, records.passthrough))
+            val sendToProducerBuffer =
+              enrichSpanWithTopics *> underlying.produce(ProducerRecords(recordsWithTraceHeaders, records.passthrough))
 
-        enrichSpanWithError(
-          "error.message-producer-buffer-send",
-          "error.cause-producer-buffer-send",
-          span,
-          sendToProducerBuffer
-        ).map(ack =>
-          tracer.locally(span) {
-            tracer.span("kafka-producer-broker-ack") {
-              enrichSpanWithError("error.message-broker-ack", "error.cause-broker-ack", span, ack)
-            }
+            enrichSpanWithError(
+              "error.message-producer-buffer-send",
+              "error.cause-producer-buffer-send",
+              span,
+              sendToProducerBuffer
+            )
+              .map(ack =>
+                tracer.locally(span) {
+                  tracer.span("kafka-producer-broker-ack") {
+                    enrichSpanWithError("error.message-broker-ack", "error.cause-broker-ack", span, ack)
+                  }
+                }
+              )
+              .onExit(finalizer)
           }
-        )
+          .onInterrupt(finalizer(Exit.unit))
       }
-    }
+  }
 
   private def enrichSpanWithError[R, E <: Throwable, A](
     errorKey: String,

--- a/fs2/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/FS2Tracer.scala
+++ b/fs2/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/FS2Tracer.scala
@@ -4,9 +4,9 @@ import cats.effect.kernel.Resource.ExitCase
 import fs2.*
 import io.janstenpickle.trace4cats.ErrorHandler
 import io.janstenpickle.trace4cats.model.{SpanKind, TraceHeaders}
-import io.kaizensolutions.trace4cats.zio.extras.{Spanned, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{ElementTracerMap, ZTracer}
 import zio.interop.catz.*
-import zio.{RIO, RManaged, ZIO}
+import zio.{Exit, RIO, ZIO, ZScope}
 
 object FS2Tracer {
   def traceEachElement[R, O](
@@ -16,17 +16,22 @@ object FS2Tracer {
     kind: SpanKind,
     errorHandler: ErrorHandler
   )(extractHeaders: O => TraceHeaders): TracedStream[R, O] =
-    stream.chunks
-      .flatMap(chunk =>
-        Stream.resource(
-          chunk
-            .traverse[RManaged[R, *], Spanned[O]](o =>
-              tracer.fromHeadersManaged(extractHeaders(o), extractName(o), kind, errorHandler).map(Spanned(_, o))
-            )
-            .toResourceZIO
-        )(concurrentInstance[R, Throwable]) // Scala 3.1.x workaround
+    Stream
+      .eval(
+        ZScope
+          .make[Exit[Any, Any]]
+          .flatMap(ElementTracerMap.make(_))
       )
-      .unchunks
+      .flatMap(tracerMap =>
+        stream
+          .evalMapChunk(element =>
+            tracerMap.traceElement(
+              element,
+              tracer.fromHeaders(extractHeaders(element), kind, extractName(element), errorHandler)
+            )
+          )
+          .onFinalizeCase(_ => tracerMap.cleanup(Exit.unit).unit)
+      )
 
   def traceEntireStream[R, O](
     tracer: ZTracer,

--- a/fs2/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/package.scala
+++ b/fs2/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/package.scala
@@ -70,6 +70,6 @@ package object fs2 {
       stream.parEvalMapUnordered[RIO[R, *], Spanned[O1]](n)(_.mapZIOTraced[R, Throwable, O1](tracer)(f))
 
     def endTracingEachElement(headers: ToHeaders = ToHeaders.standard): Stream[RIO[R, *], (O, TraceHeaders)] =
-      stream.mapChunks(_.map(s => (s.value, headers.fromContext(s.span.context))))
+      stream.evalMapChunk(s => s.closeSpan.as((s.value, headers.fromContext(s.span.context))))
   }
 }


### PR DESCRIPTION
Prevent spans from being submitted too early in streaming scenarios which can cause problems with some telemetry vendors like New Relic