### PR TITLE
traced evalMapChunk & FS2 Kafka Consumer performance improvements

### DIFF
--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
@@ -24,7 +24,7 @@ object KafkaConsumerTracer {
       .traceEachElement(tracer, consumerStream, spanNameForElement, SpanKind.Consumer, ErrorHandler.empty)(comm =>
         extractTraceHeaders(comm.record.headers)
       )
-      .evalMapWithTracer(tracer, "kafka-consumer") { comm =>
+      .evalMapChunkWithTracer(tracer, "kafka-consumer") { comm =>
         val record    = comm.record
         val topic     = record.topic
         val partition = record.partition

--- a/fs2/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/package.scala
+++ b/fs2/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/package.scala
@@ -44,6 +44,11 @@ package object fs2 {
     def evalMapTraced[O1](name: String, kind: SpanKind = SpanKind.Internal)(f: O => RIO[R, O1]): TracedStream[R, O1] =
       stream.evalMap(_.mapZIOTraced(name, kind)(f))
 
+    def evalMapChunkTraced[O1](name: String, kind: SpanKind = SpanKind.Internal)(
+      f: O => RIO[R, O1]
+    ): TracedStream[R, O1] =
+      stream.evalMapChunk(_.mapZIOTraced(name, kind)(f))
+
     def parEvalMapUnboundedTraced[O1](name: String, kind: SpanKind = SpanKind.Internal)(
       f: O => RIO[R, O1]
     ): TracedStream[R, O1] =
@@ -67,6 +72,11 @@ package object fs2 {
       f: O => RIO[R, O1]
     ): TracedStream[R, O1] =
       stream.evalMap(_.mapZIOWithTracer(tracer, name, kind)(f))
+
+    def evalMapChunkWithTracer[O1](tracer: ZTracer, name: String, kind: SpanKind = SpanKind.Internal)(
+      f: O => RIO[R, O1]
+    ): TracedStream[R, O1] =
+      stream.evalMapChunk(_.mapZIOWithTracer(tracer, name, kind)(f))
 
     def parEvalMapUnboundedWithTracer[O1](tracer: ZTracer, name: String, kind: SpanKind = SpanKind.Internal)(
       f: O => RIO[R, O1]


### PR DESCRIPTION
- Implement traced variants of evalMapChunk for FS2 and use it to improve the performance of the FS2 Kafka integration
- Use the traced variant of evalMapChunk in the Kafka Consumer Tracer implementation to improve performance by preserving chunking