### PR TITLE
Apply tracing to requests when they fail to decode or security logic

### DIFF
--- a/tapir/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptor.scala
+++ b/tapir/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptor.scala
@@ -3,6 +3,7 @@ package io.kaizensolutions.trace4cats.zio.extras.tapir
 import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
 import sttp.model.{Header, HeaderNames, StatusCode}
 import sttp.monad.MonadError
+import sttp.tapir.AnyEndpoint
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.*
@@ -105,27 +106,8 @@ private class TraceEndpointInterceptor[Env, Err](
     )(implicit
       monad: MonadError[ZIO[Env, Err, *]],
       bodyListener: BodyListener[ZIO[Env, Err, *], B]
-    ): ZIO[Env, Err, ServerResponse[B]] = {
-      val spanName     = ctx.endpoint.showShort
-      val request      = ctx.request
-      val traceHeaders = TraceHeaders.of(request.headers.map(h => (h.name, h.value))*)
-      tracer.fromHeaders(traceHeaders, name = spanName, kind = SpanKind.Server) { span =>
-        val logTraceContext =
-          if (enrichLogs) ZIOAspect.annotated(annotations = extractKVHeaders(span, headerFormat).toList*)
-          else ZIOAspect.identity
-
-        enrichSpanFromRequest(request, dropHeadersWhen, span) *>
-          (endpointHandler.onDecodeSuccess(ctx) @@ logTraceContext)
-            .foldZIO(
-              error => span.setStatus(SpanStatus.Internal(error.toString)) *> ZIO.fail(error),
-              serverResponse =>
-                enrichSpanFromResponse(serverResponse, dropHeadersWhen, span).as(
-                  if (enrichResponseHeadersWithTraceIds) serverResponse.addHeaders(toHttpHeaders(span, headerFormat))
-                  else serverResponse
-                )
-            )
-      }
-    }
+    ): ZIO[Env, Err, ServerResponse[B]] =
+      onRequestHandled(AnyContext(ctx.endpoint, ctx.request))(endpointHandler.onDecodeSuccess(ctx))
 
     override def onSecurityFailure[A](
       ctx: SecurityFailureContext[ZIO[Env, Err, *], A]
@@ -133,7 +115,7 @@ private class TraceEndpointInterceptor[Env, Err](
       monad: MonadError[ZIO[Env, Err, *]],
       bodyListener: BodyListener[ZIO[Env, Err, *], B]
     ): ZIO[Env, Err, ServerResponse[B]] =
-      endpointHandler.onSecurityFailure(ctx)
+      onRequestHandled(AnyContext(ctx.endpoint, ctx.request))(endpointHandler.onSecurityFailure(ctx))
 
     override def onDecodeFailure(
       ctx: DecodeFailureContext
@@ -141,7 +123,50 @@ private class TraceEndpointInterceptor[Env, Err](
       monad: MonadError[ZIO[Env, Err, *]],
       bodyListener: BodyListener[ZIO[Env, Err, *], B]
     ): ZIO[Env, Err, Option[ServerResponse[B]]] =
-      endpointHandler.onDecodeFailure(ctx)
+      onRequestHandled(AnyContext(ctx.endpoint, ctx.request))(endpointHandler.onDecodeFailure(ctx))
+
+    case class AnyContext(endpoint: AnyEndpoint, request: ServerRequest)
+
+    private[tapir] trait EnrichSpanFromResponse[A] {
+      def apply(a: A, span: ZSpan): UIO[A]
+    }
+    object EnrichSpanFromResponse {
+      private[tapir] def apply[A](implicit tc: EnrichSpanFromResponse[A]): EnrichSpanFromResponse[A] = tc
+
+      implicit val option: EnrichSpanFromResponse[Option[ServerResponse[B]]] =
+        new EnrichSpanFromResponse[Option[ServerResponse[B]]] {
+          def apply(a: Option[ServerResponse[B]], span: ZSpan): UIO[Option[ServerResponse[B]]] = a match {
+            case Some(res) => enrichSpanFromResponse(res, dropHeadersWhen, span).asSome
+            case None      => ZIO.none
+          }
+        }
+
+      implicit val concrete: EnrichSpanFromResponse[ServerResponse[B]] = new EnrichSpanFromResponse[ServerResponse[B]] {
+        def apply(a: ServerResponse[B], span: ZSpan): UIO[ServerResponse[B]] =
+          enrichSpanFromResponse(a, dropHeadersWhen, span)
+      }
+    }
+
+    def onRequestHandled[R, E, A: EnrichSpanFromResponse](
+      ctx: AnyContext
+    )(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] = {
+      val spanName     = ctx.endpoint.showShort
+      val request      = ctx.request
+      val traceHeaders = TraceHeaders.of(request.headers.map(h => (h.name, h.value))*)
+
+      tracer.fromHeaders(traceHeaders, name = spanName, kind = SpanKind.Server) { span =>
+        val logTraceContext =
+          if (enrichLogs) ZIOAspect.annotated(annotations = extractKVHeaders(span, headerFormat).toList*)
+          else ZIOAspect.identity
+
+        enrichSpanFromRequest(request, dropHeadersWhen, span) *>
+          (zio @@ logTraceContext)
+            .foldZIO(
+              error => span.setStatus(SpanStatus.Internal(error.toString)) *> ZIO.fail(error),
+              a => EnrichSpanFromResponse[A].apply(a, span)
+            )
+      }
+    }
   }
 
   private def toHttpHeaders(span: ZSpan, whichHeaders: ToHeaders): Seq[Header] =
@@ -162,20 +187,23 @@ private class TraceEndpointInterceptor[Env, Err](
     dropHeadersWhen: String => Boolean,
     span: ZSpan
   ): UIO[Unit] =
-    if (span.isSampled) span.putAll(requestFields(request.headers, dropHeadersWhen)*)
-    else ZIO.unit
+    span.putAll(requestFields(request.headers, dropHeadersWhen)*).whenDiscard(span.isSampled)
 
   private def enrichSpanFromResponse[A](
     response: ServerResponse[A],
     dropHeadersWhen: String => Boolean,
     span: ZSpan
-  ): UIO[Unit] = {
+  ) = {
     val respFields = {
       val statusCodeField = "resp.status.code" -> AttributeValue.intToTraceValue(response.code.code)
       statusCodeField +: responseFields(response.headers, dropHeadersWhen)
     }
-    val spanRespAttrs = if (span.isSampled) span.putAll(respFields*) else ZIO.unit
-    spanRespAttrs *> span.setStatus(toSpanStatus(response.code))
+    for {
+      _ <- span.putAll(respFields*).whenDiscard(span.isSampled)
+      _ <- span.setStatus(toSpanStatus(response.code))
+    } yield
+      if (enrichResponseHeadersWithTraceIds) response.addHeaders(toHttpHeaders(span, headerFormat))
+      else response
   }
 
   private def toSpanStatus(value: StatusCode): SpanStatus =

--- a/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TestEndpoint.scala
+++ b/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TestEndpoint.scala
@@ -1,0 +1,28 @@
+package io.kaizensolutions.trace4cats.zio.extras.tapir
+
+import io.kaizensolutions.trace4cats.zio.extras.ZTracer
+import sttp.tapir.ztapir.ZServerEndpoint
+import sttp.model.StatusCode
+import sttp.tapir.DecodeResult
+import zio.*
+import sttp.tapir.ztapir.*
+
+final case class TestEndpoint(tracer: ZTracer) {
+
+  val testEndpoint: ZServerEndpoint[Any, Any] =
+    endpoint.get
+      .securityIn(header[Option[String]]("auth"))
+      .errorOut(stringBody.and(statusCode(StatusCode.Unauthorized)))
+      .zServerSecurityLogic{
+        case None => ZIO.unit
+        case Some(v) => ZIO.whenDiscard(v == "invalid")(ZIO.fail("invalid"))
+      }
+      .in("hello" / path[String]("name") / "greeting")
+      .in(stringBody.mapDecode(s => if (s != "invalid") DecodeResult.Value(s) else DecodeResult.Error(s"$s was invalid", new Exception("nope")))(identity))
+        .serverLogic { _ => { case (name, _) =>
+          tracer.withSpan("moshi") { span =>
+            span.put("hello", name).unit
+          }
+        }
+      }
+}

--- a/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptorSpec.scala
+++ b/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptorSpec.scala
@@ -1,9 +1,10 @@
 package io.kaizensolutions.trace4cats.zio.extras.tapir
 
+import fs2.Chunk
 import io.kaizensolutions.trace4cats.zio.extras.{InMemorySpanCompleter, ZTracer}
 import org.http4s.*
 import org.http4s.syntax.all.*
-import org.typelevel.ci.CIString
+import org.typelevel.ci.{CIString, CIStringSyntax}
 import sttp.model.StatusCode
 import sttp.tapir.server.http4s.{Http4sServerInterpreter, Http4sServerOptions}
 import sttp.tapir.server.interceptor.log.DefaultServerLog
@@ -12,51 +13,68 @@ import trace4cats.{ToHeaders, TraceProcess}
 import zio.interop.catz.*
 import zio.test.*
 import zio.{Cause, Scope, Task, ZIO}
+import sttp.tapir.DecodeResult
 
 object TraceInterceptorSpec extends ZIOSpecDefault {
   final class TestEndpoint(tracer: ZTracer) {
-    private val testEndpoint =
+    val testEndpoint: ZServerEndpoint[Any, Any] =
       endpoint.get
+        .securityIn(header[Option[String]]("auth"))
+        .errorOut(stringBody)
+        .zServerSecurityLogic{
+          case None => ZIO.unit
+          case Some(v) => ZIO.whenDiscard(v == "invalid")(ZIO.fail("invalid"))
+        }
+        .errorOutVariantsFromCurrent(auth =>
+          List(oneOfVariant(auth.and(statusCode(StatusCode.Unauthorized))))
+        )
         .in("hello")
         .in(pathParam[String]("name"))
         .in("greeting")
+        .in(stringBody.mapDecode(s => if (s != "invalid") DecodeResult.Value(s) else DecodeResult.Error(s"$s was invalid", new Exception("nope")))(identity))
         .out(statusCode(StatusCode.Ok))
-
-    val serverLogic: ZServerEndpoint[Any, Any] =
-      testEndpoint.zServerLogic(name =>
-        tracer.withSpan("moshi") { span =>
-          span.put("hello", name).unit
+        .serverLogic {  _ => {
+          case (name, _) =>
+              tracer.withSpan("moshi") { span =>
+                span.put("hello", name).unit
+              }
+          }
         }
-      )
   }
 
+  case class TestContext(spanCompleter: InMemorySpanCompleter, httpApp: HttpApp[Task], tracer: ZTracer)
+
+  def makeTest = for {
+    result     <- InMemorySpanCompleter.entryPoint(TraceProcess("tapir-trace-interceptor-test"))
+    (sc, ep)    = result
+    tracer     <- InMemorySpanCompleter.toZTracer(ep)
+    interceptor = TraceInterceptor[Any, Throwable](tracer, headerFormat = ToHeaders.w3c)
+    endpoint    = new TestEndpoint(tracer)
+    httpApp = Http4sServerInterpreter[Task](
+      Http4sServerOptions
+        .customiseInterceptors[Task]
+        .prependInterceptor(interceptor)
+        .serverLog(
+          DefaultServerLog[Task](
+            doLogWhenReceived = ZIO.logInfo(_),
+            doLogWhenHandled =
+              (msg, ex) => ex.fold(ZIO.logInfo(msg))(ex => ZIO.logErrorCause(msg, Cause.fail(ex))),
+            doLogAllDecodeFailures =
+              (msg, ex) => ex.fold(ZIO.logWarning(msg))(ex => ZIO.logWarningCause(msg, Cause.fail(ex))),
+            doLogExceptions = (msg, ex) => ZIO.logErrorCause(msg, Cause.fail(ex)),
+            noLog = ZIO.unit
+          )
+        )
+        .options
+    ).toRoutes(endpoint.testEndpoint).orNotFound
+  } yield TestContext(sc, httpApp, tracer)
+
   def spec: Spec[TestEnvironment & Scope, Throwable] = suite("TraceInterceptor specification")(
-    test("traces http requests") {
+    test("traces http requests - success") {
       for {
-        result     <- InMemorySpanCompleter.entryPoint(TraceProcess("tapir-trace-interceptor-test"))
-        (sc, ep)    = result
-        tracer     <- InMemorySpanCompleter.toZTracer(ep)
-        interceptor = TraceInterceptor[Any, Throwable](tracer, headerFormat = ToHeaders.w3c)
-        endpoint    = new TestEndpoint(tracer)
-        httpApp = Http4sServerInterpreter[Task](
-                    Http4sServerOptions
-                      .customiseInterceptors[Task]
-                      .prependInterceptor(interceptor)
-                      .serverLog(
-                        DefaultServerLog[Task](
-                          doLogWhenReceived = ZIO.logInfo(_),
-                          doLogWhenHandled =
-                            (msg, ex) => ex.fold(ZIO.logInfo(msg))(ex => ZIO.logErrorCause(msg, Cause.fail(ex))),
-                          doLogAllDecodeFailures =
-                            (msg, ex) => ex.fold(ZIO.logWarning(msg))(ex => ZIO.logWarningCause(msg, Cause.fail(ex))),
-                          doLogExceptions = (msg, ex) => ZIO.logErrorCause(msg, Cause.fail(ex)),
-                          noLog = ZIO.unit
-                        )
-                      )
-                      .options
-                  ).toRoutes(endpoint.serverLogic).orNotFound
-        response <- httpApp.run(Request(uri = uri"/hello/cal/greeting"))
-        spans    <- sc.retrieveCollected
+        context <- makeTest
+        response <- context.httpApp.run(Request(uri = uri"/hello/cal/greeting").withBodyStream(fs2.Stream.chunk(Chunk.from("foo".getBytes)).covary[Task]))
+        spans    <- context.spanCompleter.retrieveCollected
         logs     <- ZTestLogger.logOutput
       } yield assertTrue(
         response.headers.get(CIString("traceparent")).isDefined,
@@ -65,6 +83,56 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
         spans.find(_.name == "moshi").exists(_.context.parent.isDefined),
         spans.exists(_.attributes.contains("hello")),
         spans.flatMap(_.attributes.get("resp.status.code")).exists(_.value.value == 200),
+        logs.exists(e =>
+          e.message().startsWith("Request: GET /hello/cal/greeting") &&
+            e.annotations.contains("traceparent")
+        )
+      )
+    },
+    test("traces http requests - decode failure") {
+      for {
+        context <- makeTest
+        a <- context.tracer.withSpan("root") { span =>
+          val headers = ToHeaders.w3c.fromContext(span.context)
+          context.httpApp.run(
+            Request(uri = uri"/hello/cal/greeting")
+              .withBodyStream(fs2.Stream.chunk(Chunk.from("invalid".getBytes)).covary[Task])
+              .withHeaders(headers.values.toSeq.map{ case (k, v) => Header.Raw(k, v)})
+          ).map(res => (res, span.context.spanId))
+        }
+        (response, rootSpanId) = a
+        spans    <- context.spanCompleter.retrieveCollected
+        logs     <- ZTestLogger.logOutput
+      } yield assertTrue(
+        response.headers.get(ci"traceparent").isDefined,
+        response.status == Status.BadRequest,
+        spans.exists(s => s.name == "GET /hello/{name}/greeting" && s.context.parent.exists(_.spanId.value sameElements rootSpanId.value)),
+        spans.flatMap(_.attributes.get("resp.status.code")).exists(_.value.value == 400),
+        logs.exists(e =>
+          e.message().startsWith("Request: GET /hello/cal/greeting") &&
+            e.annotations.contains("traceparent")
+        )
+      )
+    },
+    test("traces http requests - security failure") {
+      for {
+        context <- makeTest
+        a <- context.tracer.withSpan("root") { span =>
+          val headers = ToHeaders.w3c.fromContext(span.context)
+          context.httpApp.run(
+            Request(uri = uri"/hello/cal/greeting")
+              .withHeaders(headers.values.toSeq.map{ case (k, v) => Header.Raw(k, v)})
+              .putHeaders(Header.Raw(ci"auth", "invalid"))
+          ).map(res => (res, span.context.spanId))
+        }
+        (response, rootSpanId) = a
+        spans    <- context.spanCompleter.retrieveCollected
+        logs     <- ZTestLogger.logOutput
+      } yield assertTrue(
+        response.headers.get(ci"traceparent").isDefined,
+        response.status == Status.Unauthorized,
+        spans.exists(s => s.name == "GET /hello/{name}/greeting" && s.context.parent.exists(_.spanId.value sameElements rootSpanId.value)),
+        spans.flatMap(_.attributes.get("resp.status.code")).exists(_.value.value == 401),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
             e.annotations.contains("traceparent")


### PR DESCRIPTION
Previously, requests that fail to decode (400) or ones that fail security logic (401, 403) were not traced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized request handling for consistent span enrichment and trace header management
  * Optional augmentation of responses with trace IDs when enabled
  * More accurate capture of error status in traces for decode and security failures

* **Tests**
  * Expanded coverage for decode-failure and security-failure scenarios
  * Consolidated test setup with reusable test helper and a dedicated test endpoint for clearer verification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->