### PR TITLE
OTEL semantic convention attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ local.*
 **/.bloop/
 **/metals.sbt
 .direnv
+.kiro/
+.serena

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,9 @@ inThisBuild {
     scalaVersion       := scala213,
     crossScalaVersions := Seq(scala213, scala3),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    Test / fork := true,
+    Test / parallelExecution := true,
+    Test / testForkedParallel := true,
     versionScheme := Some("early-semver"),
     githubWorkflowJavaVersions := List(
       JavaSpec.temurin("17"),
@@ -411,6 +414,7 @@ lazy val doobie =
     .settings(kindProjectorSettings *)
     .settings(
       name := "trace4cats-zio-extras-doobie",
+      Test / javaOptions += s"-Dio.zonky.test.postgres.binary-dir=${target.value}/pg-binaries",
       libraryDependencies ++=
         Seq(
           "org.tpolecat"          %% "doobie-core"                    % Versions.doobie,
@@ -442,6 +446,7 @@ lazy val skunk =
     .settings(kindProjectorSettings *)
     .settings(
       name := "trace4cats-zio-extras-skunk",
+      Test / javaOptions += s"-Dio.zonky.test.postgres.binary-dir=${target.value}/pg-binaries",
       libraryDependencies ++=
         Seq(
           "org.tpolecat"  %% "skunk-core"        % Versions.skunk,

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/OtelSemconv.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/OtelSemconv.scala
@@ -1,0 +1,36 @@
+package io.kaizensolutions.trace4cats.zio.extras
+
+/**
+ * OpenTelemetry Semantic Convention attribute keys. See
+ * https://opentelemetry.io/docs/specs/semconv/
+ */
+object OtelSemconv {
+  // HTTP (stable)
+  val HttpRequestMethod      = "http.request.method"
+  val HttpResponseStatusCode = "http.response.status_code"
+  val HttpRoute              = "http.route"
+  val UrlFull                = "url.full"
+  val UrlPath                = "url.path"
+  val UrlScheme              = "url.scheme"
+  val ServerAddress          = "server.address"
+  val ServerPort             = "server.port"
+  val NetworkProtocolVersion = "network.protocol.version"
+  val ErrorType              = "error.type"
+
+  // Messaging
+  val MessagingSystem                 = "messaging.system"
+  val MessagingDestinationName        = "messaging.destination.name"
+  val MessagingOperationType          = "messaging.operation.type"
+  val MessagingOperationName          = "messaging.operation.name"
+  val MessagingConsumerGroupName      = "messaging.consumer.group.name"
+  val MessagingDestinationPartitionId = "messaging.destination.partition.id"
+  val MessagingKafkaMessageKey        = "messaging.kafka.message.key"
+  val MessagingKafkaOffset            = "messaging.kafka.offset"
+  val MessagingBatchMessageCount      = "messaging.batch.message_count"
+
+  // Database (stable)
+  val DbSystemName    = "db.system.name"
+  val DbQueryText     = "db.query.text"
+  val DbOperationName = "db.operation.name"
+  val DbNamespace     = "db.namespace"
+}

--- a/doobie/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactor.scala
+++ b/doobie/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactor.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import doobie.*
 import doobie.util.log
 import doobie.util.log.Parameters
-import io.kaizensolutions.trace4cats.zio.extras.ZTracer
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZTracer}
 import trace4cats.model.{AttributeValue, SpanStatus}
 import zio.*
 import zio.interop.catz.*
@@ -42,14 +42,15 @@ object TracedTransactor {
           }
           NonEmptyList
             .fromList(parameters)
-            .map(nel => "query.arguments" -> AttributeValue.StringList(nel))
+            .map(nel => "db.query.parameter.values" -> AttributeValue.StringList(nel))
             .toMap ++
             Map(
-              "query.label"      -> AttributeValue.StringValue(logEvent.label),
-              "query.execMillis" -> AttributeValue.LongValue(execution.toMillis),
-              "query.sql"        -> AttributeValue.StringValue(logEvent.sql)
+              OtelSemconv.DbSystemName    -> AttributeValue.StringValue("postgresql"),
+              OtelSemconv.DbOperationName -> AttributeValue.StringValue(logEvent.label),
+              OtelSemconv.DbQueryText     -> AttributeValue.StringValue(logEvent.sql),
+              "db.query.exec_millis"      -> AttributeValue.LongValue(execution.toMillis)
             ) ++
-            processing.map(p => "query.processingMillis" -> AttributeValue.LongValue(p.toMillis))
+            processing.map(p => "db.query.processing_millis" -> AttributeValue.LongValue(p.toMillis))
         }
 
         ZIO

--- a/doobie/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactor.scala
+++ b/doobie/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactor.scala
@@ -25,13 +25,21 @@ object TracedTransactor {
         tracer    <- ZIO.service[ZTracer]
         xa        <- ZIO.service[Transactor[Task]]
         logHander <- ZIO.service[LogHandler[Task]]
-      } yield apply(xa, tracer, logHander)
+        dbSystem  <- detectDbSystem(xa)
+      } yield apply(xa, tracer, logHander, dbSystem)
     )
 
   val default: URLayer[Transactor[Task] & ZTracer, Transactor[Task]] =
     ZLayer.succeed(LogHandler.noop[Task]) >>> layer
 
-  private def tracingLogHandler(tracer: ZTracer): LogHandler[Task] = (logEvent: log.LogEvent) => {
+  private def detectDbSystem(xa: Transactor[Task]): UIO[String] = {
+    import doobie.implicits.*
+    FC.raw(_.getMetaData.getDatabaseProductName)
+      .transact(xa)
+      .orElseSucceed("unknown")
+  }
+
+  private def tracingLogHandler(tracer: ZTracer, dbSystem: String): LogHandler[Task] = (logEvent: log.LogEvent) => {
 
     def trace(execution: FiniteDuration, processing: Option[FiniteDuration], failure: Option[Throwable]) = {
       tracer.withSpan(logEvent.sql.linesIterator.map(_.trim).mkString) { span =>
@@ -45,7 +53,7 @@ object TracedTransactor {
             .map(nel => "db.query.parameter.values" -> AttributeValue.StringList(nel))
             .toMap ++
             Map(
-              OtelSemconv.DbSystemName    -> AttributeValue.StringValue("postgresql"),
+              OtelSemconv.DbSystemName    -> AttributeValue.StringValue(dbSystem),
               OtelSemconv.DbOperationName -> AttributeValue.StringValue(logEvent.label),
               OtelSemconv.DbQueryText     -> AttributeValue.StringValue(logEvent.sql),
               "db.query.exec_millis"      -> AttributeValue.LongValue(execution.toMillis)
@@ -74,8 +82,13 @@ object TracedTransactor {
       self.run(logEvent) *> other.run(logEvent)
   }
 
-  def apply(underlying: Transactor[Task], tracer: ZTracer, logHandler: LogHandler[Task]): Transactor[Task] =
+  def apply(
+    underlying: Transactor[Task],
+    tracer: ZTracer,
+    logHandler: LogHandler[Task],
+    dbSystem: String
+  ): Transactor[Task] =
     underlying.copy(interpret0 =
-      KleisliInterpreter(logHandler.andThen(tracingLogHandler(tracer))).ConnectionInterpreter
+      KleisliInterpreter(logHandler.andThen(tracingLogHandler(tracer, dbSystem))).ConnectionInterpreter
     )
 }

--- a/doobie/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactorSpec.scala
+++ b/doobie/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactorSpec.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import doobie.Transactor
 import doobie.implicits.*
 import doobie.util.ExecutionContexts
-import io.kaizensolutions.trace4cats.zio.extras.{InMemorySpanCompleter, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{InMemorySpanCompleter, OtelSemconv, ZTracer}
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.interop.catz.*
 import zio.test.*
@@ -38,7 +38,12 @@ object TracedTransactorSpec extends ZIOSpecDefault {
           _     <- ZIO.serviceWithZIO[Transactor[Task]](xa => q.transact(xa))
           spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.retrieveCollected)
         } yield assertTrue(
-          spans.exists(span => span.name == "SELECT 1")
+          spans.exists(span =>
+            span.name == "SELECT 1" &&
+              span.attributes.collectFirst { case (OtelSemconv.DbSystemName, v) =>
+                v.value.value.asInstanceOf[String].toLowerCase
+              }.contains("postgresql")
+          )
         )
       },
       test("Captures failures") {

--- a/doobie/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactorSpec.scala
+++ b/doobie/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/doobie/TracedTransactorSpec.scala
@@ -64,7 +64,7 @@ object TracedTransactorSpec extends ZIOSpecDefault {
           spans.exists(span =>
             span.name == "SELECT ?, ?" &&
               span.attributes.exists { case (k, v) =>
-                k == "query.arguments" && v.value.value == NonEmptyList.of(p1.toString, p2.toString)
+                k == "db.query.parameter.values" && v.value.value == NonEmptyList.of(p1.toString, p2.toString)
               }
           )
         )

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
@@ -3,7 +3,7 @@ package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka
 import cats.syntax.show.*
 import cats.syntax.foldable.*
 import fs2.kafka.{ConsumerRecord, Headers}
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import trace4cats.model.{AttributeValue, SpanKind, TraceHeaders}
 import zio.{RIO, ZIOAspect}
 
@@ -27,17 +27,16 @@ object KafkaConsumerTracer {
       val topic        = record.topic
       val partition    = record.partition
       val offset       = record.offset
-      val timestamp    = record.timestamp
       val key          = record.key.toString
 
       val attributes: Map[String, AttributeValue] =
         Map(
-          "kafka.topic"           -> AttributeValue.StringValue(topic),
-          "kafka.partition"       -> AttributeValue.LongValue(partition.toLong),
-          "kafka.offset"          -> AttributeValue.LongValue(offset),
-          "kafka.create.time"     -> AttributeValue.LongValue(timestamp.createTime.getOrElse(0L)),
-          "kafka.log.append.time" -> AttributeValue.LongValue(timestamp.logAppendTime.getOrElse(0L)),
-          "kafka.key"             -> AttributeValue.StringValue(key)
+          OtelSemconv.MessagingSystem                 -> AttributeValue.StringValue("kafka"),
+          OtelSemconv.MessagingOperationType          -> AttributeValue.StringValue("process"),
+          OtelSemconv.MessagingDestinationName        -> AttributeValue.StringValue(topic),
+          OtelSemconv.MessagingDestinationPartitionId -> AttributeValue.StringValue(partition.toString),
+          OtelSemconv.MessagingKafkaOffset            -> AttributeValue.LongValue(offset),
+          OtelSemconv.MessagingKafkaMessageKey        -> AttributeValue.StringValue(key)
         )
 
       tracer.fromHeaders(headers = traceHeaders, name = spanName, kind = SpanKind.Consumer) { span =>

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaProducerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaProducerTracer.scala
@@ -2,11 +2,11 @@ package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka
 
 import cats.data.NonEmptyList
 import fs2.kafka.*
-import trace4cats.ToHeaders
+import trace4cats.{SpanStatus, ToHeaders}
 import trace4cats.model.{AttributeValue, SpanKind}
 import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import org.apache.kafka.common.{Metric, MetricName}
-import zio.ZIO
+import zio.{Trace, ZIO}
 
 object KafkaProducerTracer {
 
@@ -35,9 +35,7 @@ object KafkaProducerTracer {
         tracedProduce[R, E, K, V](tracer, underlying, headers)(records)
 
       override def metrics: ZIO[R, E, Map[MetricName, Metric]] =
-        tracer.withSpan("kafka-producer-metrics")(span =>
-          enrichSpanWithError("error.message", "error.cause", span, underlying.metrics)
-        )
+        tracer.withSpan("kafka-producer-metrics")(span => enrichSpanWithError(span, underlying.metrics))
     }
 
   def trace[R, E <: Throwable, K, V](
@@ -64,9 +62,11 @@ object KafkaProducerTracer {
               .fromList(records.map(_.topic).toList.distinct)
               .fold(ifEmpty = ZIO.unit)(topics =>
                 span.putAll(
-                  OtelSemconv.MessagingSystem          -> AttributeValue.StringValue("kafka"),
-                  OtelSemconv.MessagingOperationType   -> AttributeValue.StringValue("send"),
-                  OtelSemconv.MessagingDestinationName -> AttributeValue.StringList(topics)
+                  OtelSemconv.MessagingSystem            -> AttributeValue.StringValue("kafka"),
+                  OtelSemconv.MessagingOperationType     -> AttributeValue.StringValue("send"),
+                  OtelSemconv.MessagingOperationName     -> AttributeValue.StringValue("send"),
+                  OtelSemconv.MessagingDestinationName   -> AttributeValue.StringList(topics),
+                  OtelSemconv.MessagingBatchMessageCount -> records.size
                 )
               )
               .when(span.isSampled)
@@ -80,37 +80,58 @@ object KafkaProducerTracer {
             enrichSpanWithTopics *> underlying.produce(ProducerRecords(recordsWithTraceHeaders))
 
           enrichSpanWithError(
-            "error.message-producer-buffer-send",
-            "error.cause-producer-buffer-send",
             span,
             sendToProducerBuffer
           )
             .map(ack =>
-              // The outer span may be closed so to be safe, we extract the ID and use it to create a sub-span for the ack
-              tracer.fromHeaders(
-                headers = headers.fromContext(span.context),
-                kind = SpanKind.Producer,
-                name = "kafka-producer-broker-ack"
-              ) { span =>
-                enrichSpanWithError("error.message-broker-ack", "error.cause-broker-ack", span, ack)
-              }
+              ack
+                .tapErrorCause(cause =>
+                  // The outer span may be closed so to be safe, we extract the ID and use it to create a sub-span for the ack
+                  tracer.fromHeaders(
+                    headers = headers.fromContext(span.context),
+                    kind = SpanKind.Producer,
+                    name = "kafka-producer-broker-ack.error"
+                  ) { ackErrorSpan =>
+                    ackErrorSpan.setStatus(SpanStatus.Internal(cause.prettyPrint)) *>
+                      ackErrorSpan.putAll(
+                        OtelSemconv.ErrorType -> AttributeValue.StringValue(cause.squash.getClass.getCanonicalName)
+                      )
+                  }
+                )
+                .tap(results =>
+                  ZIO.foreachParDiscard(results.asSeq) { case (_, meta) =>
+                    // The outer span may be closed so to be safe, we extract the ID and use it to create a sub-span for the ack
+                    tracer.fromHeaders(
+                      headers = headers.fromContext(span.context),
+                      kind = SpanKind.Producer,
+                      name = "kafka-producer-broker-ack"
+                    ) { ackSpan =>
+                      ackSpan.putAll(
+                        OtelSemconv.MessagingOperationName -> AttributeValue.StringValue("ack"),
+                        OtelSemconv.MessagingDestinationPartitionId -> AttributeValue
+                          .LongValue(meta.partition().toLong),
+                        OtelSemconv.MessagingKafkaOffset -> AttributeValue.LongValue(meta.offset())
+                      )
+                    }
+                  }
+                )
             )
         }
     }
 
   private def enrichSpanWithError[R, E <: Throwable, A](
-    errorKey: String,
-    causeKey: String,
     span: ZSpan,
     in: ZIO[R, E, A]
-  ): ZIO[R, E, A] =
-    in
-      .tapError(e =>
-        if (span.isSampled) span.put(errorKey, AttributeValue.StringValue(e.getLocalizedMessage))
-        else ZIO.unit
-      )
-      .tapDefect(c =>
-        if (span.isSampled) span.put(causeKey, AttributeValue.StringValue(c.prettyPrint))
-        else ZIO.unit
-      )
+  )(implicit trace: Trace): ZIO[R, E, A] =
+    in.tapErrorCause(cause =>
+      span.setStatus(SpanStatus.Internal(cause.prettyPrint)) *>
+        span.putAll(
+          OtelSemconv.ErrorType -> AttributeValue.StringValue(cause.squash.getClass.getCanonicalName),
+          "zio.cause.type" -> {
+            if (cause.isDie) "defect"
+            else if (cause.isInterrupted) "interrupted"
+            else "failure"
+          }
+        )
+    )
 }

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaProducerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaProducerTracer.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import fs2.kafka.*
 import trace4cats.ToHeaders
 import trace4cats.model.{AttributeValue, SpanKind}
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import org.apache.kafka.common.{Metric, MetricName}
 import zio.ZIO
 
@@ -62,7 +62,13 @@ object KafkaProducerTracer {
           val enrichSpanWithTopics =
             NonEmptyList
               .fromList(records.map(_.topic).toList.distinct)
-              .fold(ifEmpty = ZIO.unit)(topics => span.put("topics", AttributeValue.StringList(topics)))
+              .fold(ifEmpty = ZIO.unit)(topics =>
+                span.putAll(
+                  OtelSemconv.MessagingSystem          -> AttributeValue.StringValue("kafka"),
+                  OtelSemconv.MessagingOperationType   -> AttributeValue.StringValue("send"),
+                  OtelSemconv.MessagingDestinationName -> AttributeValue.StringList(topics)
+                )
+              )
               .when(span.isSampled)
 
           val kafkaTraceHeaders =

--- a/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
+++ b/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
@@ -74,7 +74,7 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
             span.name == "kafka-producer-send-buffer" &&
               span.kind == SpanKind.Producer &&
               span.attributes.exists { case (k, v) =>
-                k == "topics" &&
+                k == "messaging.destination.name" &&
                 v.value.value == NonEmptyList.of(topic)
               }
           )

--- a/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
+++ b/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
@@ -67,7 +67,7 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
         val topic = UUID.randomUUID().toString
         for {
           producer <- ZIO.service[Producer]
-          _        <- producer.produceOne(topic, "key", "value")
+          _        <- producer.produceOne(topic, "key", "value").flatten
           spans    <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.retrieveCollected)
         } yield assertTrue(
           spans.exists(span =>

--- a/http4s/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/http4s/client/Http4sClientTracer.scala
+++ b/http4s/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/http4s/client/Http4sClientTracer.scala
@@ -5,9 +5,9 @@ import trace4cats.ToHeaders
 import trace4cats.http4s.common.{Http4sHeaders, Http4sSpanNamer, Http4sStatusMapping, Request_, Response_}
 import trace4cats.model.*
 import trace4cats.model.AttributeValue.{LongValue, StringValue}
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import org.http4s.client.{Client, UnexpectedStatus}
-import org.http4s.{Headers, Response, Uri}
+import org.http4s.{Headers, Response}
 import zio.*
 import zio.interop.catz.*
 
@@ -69,18 +69,13 @@ object Http4sClientTracer {
 
   private def toAttributes(req: Request_): Map[String, AttributeValue] =
     Map[String, AttributeValue](
-      SemanticAttributeKeys.httpFlavor -> s"${req.httpVersion.major}.${req.httpVersion.minor}",
-      SemanticAttributeKeys.httpMethod -> req.method.name,
-      SemanticAttributeKeys.httpUrl    -> req.uri.toString
+      OtelSemconv.NetworkProtocolVersion -> s"${req.httpVersion.major}.${req.httpVersion.minor}",
+      OtelSemconv.HttpRequestMethod      -> req.method.name,
+      OtelSemconv.UrlFull                -> req.uri.toString
     ) ++ req.uri.host.map { host =>
-      val key = host match {
-        case _: Uri.Ipv4Address => SemanticAttributeKeys.remoteServiceIpv4
-        case _: Uri.Ipv6Address => SemanticAttributeKeys.remoteServiceIpv6
-        case _: Uri.RegName     => SemanticAttributeKeys.remoteServiceHostname
-      }
-      key -> StringValue(host.value)
-    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.remoteServicePort -> LongValue(port.toLong))
+      OtelSemconv.ServerAddress -> StringValue(host.value)
+    }.toMap ++ req.uri.port.map(port => OtelSemconv.ServerPort -> LongValue(port.toLong))
 
   def toAttributes(res: Response_): Map[String, AttributeValue] =
-    Map[String, AttributeValue](SemanticAttributeKeys.httpStatusCode -> res.status.code)
+    Map[String, AttributeValue](OtelSemconv.HttpResponseStatusCode -> res.status.code)
 }

--- a/http4s/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/http4s/client/Http4sClientTracerSpec.scala
+++ b/http4s/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/http4s/client/Http4sClientTracerSpec.scala
@@ -27,8 +27,8 @@ object Http4sClientTracerSpec extends ZIOSpecDefault {
           val span = spans.head
           assertTrue(
             span.name == "GET /hello",
-            span.attributes("http.status_code").value.value == 200,
-            span.attributes("http.url").value.value == "/hello"
+            span.attributes("http.response.status_code").value.value == 200,
+            span.attributes("url.full").value.value == "/hello"
           )
         }
       } +
@@ -42,7 +42,7 @@ object Http4sClientTracerSpec extends ZIOSpecDefault {
             val span = spans.head
             assertTrue(
               span.name == "GET /hello",
-              span.attributes("http.url").value.value == "/hello",
+              span.attributes("url.full").value.value == "/hello",
               span.attributes("error.message").value.value == "An error has occurred",
               span.status == SpanStatus.Internal("An error has occurred")
             )
@@ -67,7 +67,7 @@ object Http4sClientTracerSpec extends ZIOSpecDefault {
             val span = spans.head
             assertTrue(
               span.name == "GET /hello",
-              span.attributes("http.url").value.value == "/hello", {
+              span.attributes("url.full").value.value == "/hello", {
                 val cause = span.attributes("error.cause").value.value.toString
                 cause.contains("A defect has occurred") &&
                 cause.contains("Another defect has occurred")

--- a/skunk/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/skunk/TracedSession.scala
+++ b/skunk/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/skunk/TracedSession.scala
@@ -2,7 +2,7 @@ package io.kaizensolutions.trace4cats.zio.extras.skunk
 
 import cats.effect.Resource
 import cats.effect.kernel.Resource.ExitCase
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import fs2.*
 import fs2.concurrent.Signal
 import skunk.*
@@ -361,7 +361,7 @@ final class TracedSession(underlying: Session[Task], tracer: ZTracer) extends Se
         // WARNING: mutable (builder) state is used here as this is on the hot path
         var index   = 1
         val builder = Map.newBuilder[String, AttributeValue]
-        builder.sizeHint(values.size)
+        builder.sizeHint(values.size + 4)
 
         values.foreach { value =>
           val attr = AttributeValue.StringValue(value.getOrElse("<null>"))
@@ -369,6 +369,8 @@ final class TracedSession(underlying: Session[Task], tracer: ZTracer) extends Se
           index += 1
         }
 
+        builder += ((OtelSemconv.DbSystemName, AttributeValue.StringValue("postgresql")))
+        builder += ((OtelSemconv.DbQueryText, AttributeValue.StringValue(statement.sql)))
         builder += (("skunk.method", AttributeValue.StringValue(methodName)))
         builder += (("prepared", AttributeValue.BooleanValue(prepared)))
 

--- a/sttp/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp/SttpBackendTracer.scala
+++ b/sttp/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp/SttpBackendTracer.scala
@@ -1,6 +1,6 @@
 package io.kaizensolutions.trace4cats.zio.extras.sttp
 
-import io.kaizensolutions.trace4cats.zio.extras.ZTracer
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZTracer}
 import sttp.capabilities.Effect
 import sttp.client3.impl.zio.RIOMonadAsyncError
 import sttp.client3.{HttpError, Request, Response, SttpBackend}
@@ -87,36 +87,24 @@ object SttpBackendTracer {
     case _                                       => SpanStatus.Unknown
   }
 
-  private val ipv4Regex =
-    "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$".r
-
-  private val ipv6Regex =
-    "^(?:(?:(?:[A-F0-9]{1,4}:){6}|(?=(?:[A-F0-9]{0,4}:){0,6}(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$)(([0-9A-F]{1,4}:){0,5}|:)((:[0-9A-F]{1,4}){1,5}:|:))(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:))$".r
-
   private def toAttributes[T, R](req: Request[T, R]): Map[String, AttributeValue] =
     req.uri.host.map { host =>
-      val key = host.toUpperCase match {
-        case ipv4Regex(_*) => SemanticAttributeKeys.remoteServiceIpv4
-        case ipv6Regex(_*) => SemanticAttributeKeys.remoteServiceIpv6
-        case _             => SemanticAttributeKeys.remoteServiceHostname
-      }
-
-      key -> StringValue(host)
-    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.remoteServicePort -> LongValue(port.toLong))
+      OtelSemconv.ServerAddress -> StringValue(host)
+    }.toMap ++ req.uri.port.map(port => OtelSemconv.ServerPort -> LongValue(port.toLong))
 
   private def requestFields(
     hs: Headers,
     dropHeadersWhen: String => Boolean
   ): List[(String, AttributeValue)] =
-    headerFields(hs, "req", dropHeadersWhen)
+    headerFields(hs, "request", dropHeadersWhen)
 
   private def responseFields[A](
     res: Response[A],
     dropHeadersWhen: String => Boolean
   ): List[(String, AttributeValue)] =
-    headerFields(Headers(res.headers), "resp", dropHeadersWhen) ++
+    headerFields(Headers(res.headers), "response", dropHeadersWhen) ++
       List(
-        "resp.status.code" -> res.code.code
+        OtelSemconv.HttpResponseStatusCode -> res.code.code
       )
 
   private def headerFields(
@@ -127,7 +115,7 @@ object SttpBackendTracer {
     hs.headers
       .filter(h => !dropHeadersWhen(h.name))
       .map { h =>
-        (s"${`type`}.header.${h.name}", h.value: AttributeValue)
+        (s"http.${`type`}.header.${h.name.toLowerCase}", h.value: AttributeValue)
       }
       .toList
 }

--- a/sttp/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/sttp/SttpBackendTracerSpec.scala
+++ b/sttp/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/sttp/SttpBackendTracerSpec.scala
@@ -43,9 +43,9 @@ object SttpBackendTracerSpec extends ZIOSpecDefault {
         logs.filter(_.message().contains("GET /foo/bar")).forall(_.annotations.contains("X-B3-TraceId")),
         spans.size == 1,
         spans.exists(_.name == "GET /foo/bar"),
-        spans.exists(_.attributes.get("remote.service.hostname").exists(_.value.value == "host")),
+        spans.exists(_.attributes.get("server.address").exists(_.value.value == "host")),
         spans.exists(_.status.isOk),
-        spans.exists(_.attributes.get("resp.status.code").exists(_.value.value == 200))
+        spans.exists(_.attributes.get("http.response.status_code").exists(_.value.value == 200))
       )
     }
   ).provide(

--- a/sttp4/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp4/BackendTracer.scala
+++ b/sttp4/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp4/BackendTracer.scala
@@ -1,6 +1,6 @@
 package io.kaizensolutions.trace4cats.zio.extras.sttp4
 
-import io.kaizensolutions.trace4cats.zio.extras.ZTracer
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZTracer}
 import sttp.capabilities.Effect
 import sttp.client4.impl.zio.RIOMonadAsyncError
 import sttp.client4.{Backend, GenericRequest, Response, ResponseException}
@@ -89,36 +89,24 @@ object BackendTracer {
     case _                                       => SpanStatus.Unknown
   }
 
-  private val ipv4Regex =
-    "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$".r
-
-  private val ipv6Regex =
-    "^(?:(?:(?:[A-F0-9]{1,4}:){6}|(?=(?:[A-F0-9]{0,4}:){0,6}(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$)(([0-9A-F]{1,4}:){0,5}|:)((:[0-9A-F]{1,4}){1,5}:|:))(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:))$".r
-
   private def toAttributes[T](req: GenericRequest[?, Effect[Task]]): Map[String, AttributeValue] =
     req.uri.host.map { host =>
-      val key = host.toUpperCase match {
-        case ipv4Regex(_*) => SemanticAttributeKeys.remoteServiceIpv4
-        case ipv6Regex(_*) => SemanticAttributeKeys.remoteServiceIpv6
-        case _             => SemanticAttributeKeys.remoteServiceHostname
-      }
-
-      key -> StringValue(host)
-    }.toMap ++ req.uri.port.map(port => SemanticAttributeKeys.remoteServicePort -> LongValue(port.toLong))
+      OtelSemconv.ServerAddress -> StringValue(host)
+    }.toMap ++ req.uri.port.map(port => OtelSemconv.ServerPort -> LongValue(port.toLong))
 
   private def requestFields(
     hs: Headers,
     dropHeadersWhen: String => Boolean
   ): List[(String, AttributeValue)] =
-    headerFields(hs, "req", dropHeadersWhen)
+    headerFields(hs, "request", dropHeadersWhen)
 
   private def responseFields[A](
     res: Response[A],
     dropHeadersWhen: String => Boolean
   ): List[(String, AttributeValue)] =
-    headerFields(Headers(res.headers), "resp", dropHeadersWhen) ++
+    headerFields(Headers(res.headers), "response", dropHeadersWhen) ++
       List(
-        "resp.status.code" -> res.code.code
+        OtelSemconv.HttpResponseStatusCode -> res.code.code
       )
 
   private def headerFields(
@@ -129,7 +117,7 @@ object BackendTracer {
     hs.headers
       .filter(h => !dropHeadersWhen(h.name))
       .map { h =>
-        (s"${`type`}.header.${h.name}", h.value: AttributeValue)
+        (s"http.${`type`}.header.${h.name.toLowerCase}", h.value: AttributeValue)
       }
       .toList
 }

--- a/sttp4/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/sttp4/BackendTracerSpec.scala
+++ b/sttp4/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/sttp4/BackendTracerSpec.scala
@@ -47,9 +47,9 @@ object BackendTracerSpec extends ZIOSpecDefault {
         logs.filter(_.message().contains("GET /foo/bar")).forall(_.annotations.contains("X-B3-TraceId")),
         spans.size == 1,
         spans.exists(_.name == "GET /foo/bar"),
-        spans.exists(_.attributes.get("remote.service.hostname").exists(_.value.value == "host")),
+        spans.exists(_.attributes.get("server.address").exists(_.value.value == "host")),
         spans.exists(_.status.isOk),
-        spans.exists(_.attributes.get("resp.status.code").exists(_.value.value == 200))
+        spans.exists(_.attributes.get("http.response.status_code").exists(_.value.value == 200))
       )
     }
   ).provide(

--- a/tapir/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptor.scala
+++ b/tapir/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptor.scala
@@ -1,6 +1,6 @@
 package io.kaizensolutions.trace4cats.zio.extras.tapir
 
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import sttp.model.{Header, HeaderNames, StatusCode}
 import sttp.monad.MonadError
 import sttp.tapir.AnyEndpoint
@@ -195,7 +195,7 @@ private class TraceEndpointInterceptor[Env, Err](
     span: ZSpan
   ) = {
     val respFields = {
-      val statusCodeField = "resp.status.code" -> AttributeValue.intToTraceValue(response.code.code)
+      val statusCodeField = OtelSemconv.HttpResponseStatusCode -> AttributeValue.LongValue(response.code.code.toLong)
       statusCodeField +: responseFields(response.headers, dropHeadersWhen)
     }
     for {
@@ -224,13 +224,13 @@ private class TraceEndpointInterceptor[Env, Err](
     hs: Seq[Header],
     dropHeadersWhen: String => Boolean
   ): Seq[(String, AttributeValue)] =
-    headerFields(hs, "req", dropHeadersWhen)
+    headerFields(hs, "request", dropHeadersWhen)
 
   private def responseFields(
     hs: Seq[Header],
     dropHeadersWhen: String => Boolean
   ): Seq[(String, AttributeValue)] =
-    headerFields(hs, "resp", dropHeadersWhen)
+    headerFields(hs, "response", dropHeadersWhen)
 
   private def headerFields(
     hs: Seq[Header],
@@ -238,6 +238,6 @@ private class TraceEndpointInterceptor[Env, Err](
     dropHeadersWhen: String => Boolean
   ): Seq[(String, AttributeValue)] =
     hs.filter(h => !dropHeadersWhen(h.name)).map { h =>
-      (s"${`type`}.header.${h.name}", h.value: AttributeValue)
+      (s"http.${`type`}.header.${h.name.toLowerCase}", h.value: AttributeValue)
     }
 }

--- a/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TestEndpoint.scala
+++ b/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TestEndpoint.scala
@@ -13,13 +13,18 @@ final case class TestEndpoint(tracer: ZTracer) {
     endpoint.get
       .securityIn(header[Option[String]]("auth"))
       .errorOut(stringBody.and(statusCode(StatusCode.Unauthorized)))
-      .zServerSecurityLogic{
-        case None => ZIO.unit
+      .zServerSecurityLogic {
+        case None    => ZIO.unit
         case Some(v) => ZIO.whenDiscard(v == "invalid")(ZIO.fail("invalid"))
       }
       .in("hello" / path[String]("name") / "greeting")
-      .in(stringBody.mapDecode(s => if (s != "invalid") DecodeResult.Value(s) else DecodeResult.Error(s"$s was invalid", new Exception("nope")))(identity))
-        .serverLogic { _ => { case (name, _) =>
+      .in(
+        stringBody.mapDecode(s =>
+          if (s != "invalid") DecodeResult.Value(s) else DecodeResult.Error(s"$s was invalid", new Exception("nope"))
+        )(identity)
+      )
+      .serverLogic { _ =>
+        { case (name, _) =>
           tracer.withSpan("moshi") { span =>
             span.put("hello", name).unit
           }

--- a/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptorSpec.scala
+++ b/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptorSpec.scala
@@ -23,38 +23,41 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
     interceptor = TraceInterceptor.task(tracer, headerFormat = ToHeaders.w3c)
     endpoint    = TestEndpoint(tracer)
     httpApp = Http4sServerInterpreter[Task](
-      Http4sServerOptions
-        .customiseInterceptors[Task]
-        .prependInterceptor(interceptor)
-        .serverLog(
-          DefaultServerLog[Task](
-            doLogWhenReceived = ZIO.logInfo(_),
-            doLogWhenHandled =
-              (msg, ex) => ex.fold(ZIO.logInfo(msg))(ex => ZIO.logErrorCause(msg, Cause.fail(ex))),
-            doLogAllDecodeFailures =
-              (msg, ex) => ex.fold(ZIO.logWarning(msg))(ex => ZIO.logWarningCause(msg, Cause.fail(ex))),
-            doLogExceptions = (msg, ex) => ZIO.logErrorCause(msg, Cause.fail(ex)),
-            noLog = ZIO.unit
-          )
-        )
-        .options
-    ).toRoutes(endpoint.testEndpoint).orNotFound
+                Http4sServerOptions
+                  .customiseInterceptors[Task]
+                  .prependInterceptor(interceptor)
+                  .serverLog(
+                    DefaultServerLog[Task](
+                      doLogWhenReceived = ZIO.logInfo(_),
+                      doLogWhenHandled =
+                        (msg, ex) => ex.fold(ZIO.logInfo(msg))(ex => ZIO.logErrorCause(msg, Cause.fail(ex))),
+                      doLogAllDecodeFailures =
+                        (msg, ex) => ex.fold(ZIO.logWarning(msg))(ex => ZIO.logWarningCause(msg, Cause.fail(ex))),
+                      doLogExceptions = (msg, ex) => ZIO.logErrorCause(msg, Cause.fail(ex)),
+                      noLog = ZIO.unit
+                    )
+                  )
+                  .options
+              ).toRoutes(endpoint.testEndpoint).orNotFound
   } yield TestContext(sc, httpApp, tracer)
 
   def spec: Spec[TestEnvironment & Scope, Throwable] = suite("TraceInterceptor specification")(
     test("traces http requests - success") {
       for {
         context <- makeTest
-        response <- context.httpApp.run(Request(uri = uri"/hello/cal/greeting").withBodyStream(fs2.Stream.chunk(Chunk.from("foo".getBytes)).covary[Task]))
-        spans    <- context.spanCompleter.retrieveCollected
-        logs     <- ZTestLogger.logOutput
+        response <- context.httpApp.run(
+                      Request(uri = uri"/hello/cal/greeting")
+                        .withBodyStream(fs2.Stream.chunk(Chunk.from("foo".getBytes)).covary[Task])
+                    )
+        spans <- context.spanCompleter.retrieveCollected
+        logs  <- ZTestLogger.logOutput
       } yield assertTrue(
         response.headers.get(ci"traceparent").isDefined,
         response.status == Status.Ok,
         spans.exists(_.name == "GET /hello/{name}/greeting"),
         spans.find(_.name == "moshi").exists(_.context.parent.isDefined),
         spans.exists(_.attributes.contains("hello")),
-        spans.flatMap(_.attributes.get("resp.status.code")).exists(_.value.value == 200),
+        spans.flatMap(_.attributes.get("http.response.status_code")).exists(_.value.value == 200),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
             e.annotations.contains("traceparent")
@@ -65,21 +68,26 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
       for {
         context <- makeTest
         a <- context.tracer.withSpan("root") { span =>
-          val headers = ToHeaders.w3c.fromContext(span.context)
-          context.httpApp.run(
-            Request(uri = uri"/hello/cal/greeting")
-              .withBodyStream(fs2.Stream.chunk(Chunk.from("invalid".getBytes)).covary[Task])
-              .withHeaders(headers.values.toSeq.map{ case (k, v) => Header.Raw(k, v)})
-          ).map(res => (res, span.context.spanId))
-        }
+               val headers = ToHeaders.w3c.fromContext(span.context)
+               context.httpApp
+                 .run(
+                   Request(uri = uri"/hello/cal/greeting")
+                     .withBodyStream(fs2.Stream.chunk(Chunk.from("invalid".getBytes)).covary[Task])
+                     .withHeaders(headers.values.toSeq.map { case (k, v) => Header.Raw(k, v) })
+                 )
+                 .map(res => (res, span.context.spanId))
+             }
         (response, rootSpanId) = a
-        spans    <- context.spanCompleter.retrieveCollected
-        logs     <- ZTestLogger.logOutput
+        spans                 <- context.spanCompleter.retrieveCollected
+        logs                  <- ZTestLogger.logOutput
       } yield assertTrue(
         response.headers.get(ci"traceparent").isDefined,
         response.status == Status.BadRequest,
-        spans.exists(s => s.name == "GET /hello/{name}/greeting" && s.context.parent.exists(_.spanId.value sameElements rootSpanId.value)),
-        spans.flatMap(_.attributes.get("resp.status.code")).exists(_.value.value == 400),
+        spans.exists(s =>
+          s.name == "GET /hello/{name}/greeting" && s.context.parent
+            .exists(_.spanId.value.sameElements(rootSpanId.value))
+        ),
+        spans.flatMap(_.attributes.get("http.response.status_code")).exists(_.value.value == 400),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
             e.annotations.contains("traceparent")
@@ -90,21 +98,26 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
       for {
         context <- makeTest
         a <- context.tracer.withSpan("root") { span =>
-          val headers = ToHeaders.w3c.fromContext(span.context)
-          context.httpApp.run(
-            Request(uri = uri"/hello/cal/greeting")
-              .withHeaders(headers.values.toSeq.map{ case (k, v) => Header.Raw(k, v)})
-              .putHeaders(Header.Raw(ci"auth", "invalid"))
-          ).map(res => (res, span.context.spanId))
-        }
+               val headers = ToHeaders.w3c.fromContext(span.context)
+               context.httpApp
+                 .run(
+                   Request(uri = uri"/hello/cal/greeting")
+                     .withHeaders(headers.values.toSeq.map { case (k, v) => Header.Raw(k, v) })
+                     .putHeaders(Header.Raw(ci"auth", "invalid"))
+                 )
+                 .map(res => (res, span.context.spanId))
+             }
         (response, rootSpanId) = a
-        spans    <- context.spanCompleter.retrieveCollected
-        logs     <- ZTestLogger.logOutput
+        spans                 <- context.spanCompleter.retrieveCollected
+        logs                  <- ZTestLogger.logOutput
       } yield assertTrue(
         response.headers.get(ci"traceparent").isDefined,
         response.status == Status.Unauthorized,
-        spans.exists(s => s.name == "GET /hello/{name}/greeting" && s.context.parent.exists(_.spanId.value sameElements rootSpanId.value)),
-        spans.flatMap(_.attributes.get("resp.status.code")).exists(_.value.value == 401),
+        spans.exists(s =>
+          s.name == "GET /hello/{name}/greeting" && s.context.parent
+            .exists(_.spanId.value.sameElements(rootSpanId.value))
+        ),
+        spans.flatMap(_.attributes.get("http.response.status_code")).exists(_.value.value == 401),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
             e.annotations.contains("traceparent")

--- a/virgil/src/main/scala/io/kaizensolutions/virgil/trace4cats/zio/extras/TracedCQLExecutor.scala
+++ b/virgil/src/main/scala/io/kaizensolutions/virgil/trace4cats/zio/extras/TracedCQLExecutor.scala
@@ -3,7 +3,7 @@ package io.kaizensolutions.virgil.trace4cats.zio.extras
 import com.datastax.oss.driver.api.core.metrics.Metrics
 import com.datastax.oss.driver.api.core.{CqlSession, CqlSessionBuilder}
 import trace4cats.model.{AttributeValue, SampleDecision, SpanKind, SpanStatus}
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import io.kaizensolutions.virgil.codecs.DecoderException
 import io.kaizensolutions.virgil.configuration.PageState
 import io.kaizensolutions.virgil.internal.CqlStatementRenderer
@@ -157,8 +157,9 @@ class TracedCQLExecutor(underlying: CQLExecutor, tracer: ZTracer, dropMarkerFrom
         val attrMap      = mutable.Map.empty[String, AttributeValue]
         val (_, markers) = CqlStatementRenderer.render(q)
 
-        attrMap += ("virgil.query-type"       -> AttributeValue.StringValue("query"))
-        attrMap += ("virgil.elements-to-pull" -> AttributeValue.StringValue(pullMode.toString))
+        attrMap += (OtelSemconv.DbSystemName    -> AttributeValue.StringValue("cassandra"))
+        attrMap += (OtelSemconv.DbOperationName -> AttributeValue.StringValue("query"))
+        attrMap += ("virgil.elements-to-pull"   -> AttributeValue.StringValue(pullMode.toString))
         markers.underlying.foreach { m =>
           val (name, marker) = m
           if (dropMarkerFromSpan(name.name)) ()
@@ -170,7 +171,8 @@ class TracedCQLExecutor(underlying: CQLExecutor, tracer: ZTracer, dropMarkerFrom
         val attrMap      = mutable.Map.empty[String, AttributeValue]
         val (_, markers) = CqlStatementRenderer.render(mutation)
 
-        attrMap += ("virgil.query-type" -> AttributeValue.StringValue("mutation"))
+        attrMap += (OtelSemconv.DbSystemName    -> AttributeValue.StringValue("cassandra"))
+        attrMap += (OtelSemconv.DbOperationName -> AttributeValue.StringValue("mutation"))
         markers.underlying.foreach { m =>
           val (name, marker) = m
           if (dropMarkerFromSpan(name.name)) ()
@@ -181,8 +183,9 @@ class TracedCQLExecutor(underlying: CQLExecutor, tracer: ZTracer, dropMarkerFrom
       case CQLType.Batch(mutations, batchType: BatchType) =>
         var queryCounter = 0
         val attrMap      = mutable.Map.empty[String, AttributeValue]
-        attrMap += ("virgil.batch-type" -> AttributeValue.StringValue(batchType.toString))
-        attrMap += ("virgil.query-type" -> AttributeValue.StringValue("batch-mutation"))
+        attrMap += (OtelSemconv.DbSystemName    -> AttributeValue.StringValue("cassandra"))
+        attrMap += (OtelSemconv.DbOperationName -> AttributeValue.StringValue("batch-mutation"))
+        attrMap += ("virgil.batch-type"         -> AttributeValue.StringValue(batchType.toString))
 
         mutations.foreach { mut =>
           val (qs, markers) = CqlStatementRenderer.render(mut)

--- a/virgil/src/test/scala/io/kaizensolutions/virgil/trace4cats/zio/extras/TracedCQLExecutorSpec.scala
+++ b/virgil/src/test/scala/io/kaizensolutions/virgil/trace4cats/zio/extras/TracedCQLExecutorSpec.scala
@@ -36,7 +36,7 @@ object TracedCQLExecutorSpec extends ZIOSpecDefault {
           assertTrue(
             span.name == "SELECT id, data FROM example_table WHERE id = :id_relation",
             span.attributes("virgil.bind-markers.id_relation").value.value == "1",
-            span.attributes("virgil.query-type").value.value == "query",
+            span.attributes("db.operation.name").value.value == "query",
             span.attributes("virgil.elements-to-pull").value.value == "All"
           )
         }
@@ -60,7 +60,7 @@ object TracedCQLExecutorSpec extends ZIOSpecDefault {
             val span = spans.head
             assertTrue(
               span.name == "BATCH(UPDATE cycling.popular_count SET popularity = popularity + :param0 WHERE id = :param1;UPDATE cycling.popular_count SET popularity = popularity + :param0 WHERE id = :param1;UPDATE cycling.popular_count SET popularity = popularity - :param0 WHERE id = :param1;)",
-              span.attributes("virgil.query-type").value.value == "batch-mutation",
+              span.attributes("db.operation.name").value.value == "batch-mutation",
               span
                 .attributes("virgil.query.0")
                 .value
@@ -101,7 +101,7 @@ object TracedCQLExecutorSpec extends ZIOSpecDefault {
             assertTrue(
               span.name == "page-begin: SELECT id, data FROM example_table WHERE id = :id_relation",
               span.attributes("virgil.bind-markers.id_relation").value.value == "1",
-              span.attributes("virgil.query-type").value.value == "query"
+              span.attributes("db.operation.name").value.value == "query"
             )
           }
         }

--- a/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/client/ZioHttpClientTracer.scala
+++ b/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/client/ZioHttpClientTracer.scala
@@ -1,10 +1,9 @@
 package io.kaizensolutions.trace4cats.zio.extras.ziohttp.client
 
-import io.kaizensolutions.trace4cats.zio.extras.ZTracer
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZTracer}
 import io.kaizensolutions.trace4cats.zio.extras.ziohttp.toSpanStatus
 import trace4cats.model.AttributeValue.{LongValue, StringValue}
-import trace4cats.model.SemanticAttributeKeys.{serviceHostname, servicePort}
-import trace4cats.model.{AttributeValue, SampleDecision, SemanticAttributeKeys, SpanKind}
+import trace4cats.model.{AttributeValue, SampleDecision, SpanKind}
 import trace4cats.{ErrorHandler, ToHeaders}
 import zio.*
 import zio.http.*
@@ -109,13 +108,13 @@ object ZioHttpClientTracer {
 
   private def toAttributes(req: Request): Map[String, AttributeValue] =
     Map[String, AttributeValue](
-      SemanticAttributeKeys.httpFlavor -> req.version.toString,
-      SemanticAttributeKeys.httpMethod -> req.method.toString(),
-      SemanticAttributeKeys.httpUrl    -> req.url.path.toString
+      OtelSemconv.NetworkProtocolVersion -> req.version.toString,
+      OtelSemconv.HttpRequestMethod      -> req.method.toString(),
+      OtelSemconv.UrlFull                -> req.url.encode
     ) ++
-      req.url.host.map(host => serviceHostname -> StringValue(host)) ++
-      req.url.port.map(port => servicePort -> LongValue(port.toLong))
+      req.url.host.map(host => OtelSemconv.ServerAddress -> StringValue(host)) ++
+      req.url.port.map(port => OtelSemconv.ServerPort -> LongValue(port.toLong))
 
   private def toAttributes(resp: Response): Map[String, AttributeValue] =
-    Map[String, AttributeValue](SemanticAttributeKeys.httpStatusCode -> resp.status.code)
+    Map[String, AttributeValue](OtelSemconv.HttpResponseStatusCode -> resp.status.code)
 }

--- a/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/server/ZioHttpServerTracer.scala
+++ b/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/server/ZioHttpServerTracer.scala
@@ -124,9 +124,9 @@ object ZioHttpServerTracer {
       OtelSemconv.NetworkProtocolVersion -> renderHttpVersion(req.version),
       OtelSemconv.HttpRequestMethod      -> req.method.toString,
       OtelSemconv.UrlPath                -> req.url.path.toString
-    ) ++ 
-    req.url.scheme.map(scheme => OtelSemconv.UrlScheme  -> StringValue(scheme.encode)) ++
-    headerFields(headers = req.headers, `type` = "request", dropWhen = dropHeadersWhen) ++
+    ) ++
+      req.url.scheme.map(scheme => OtelSemconv.UrlScheme -> StringValue(scheme.encode)) ++
+      headerFields(headers = req.headers, `type` = "request", dropWhen = dropHeadersWhen) ++
       req.url.host.map(host => OtelSemconv.ServerAddress -> StringValue(host)) ++
       req.url.port.map(port => OtelSemconv.ServerPort -> LongValue(port.toLong))
 

--- a/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/server/ZioHttpServerTracer.scala
+++ b/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/server/ZioHttpServerTracer.scala
@@ -1,9 +1,8 @@
 package io.kaizensolutions.trace4cats.zio.extras.ziohttp.server
 
 import io.kaizensolutions.trace4cats.zio.extras.ziohttp.{extractTraceHeaders, toSpanStatus}
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import trace4cats.model.AttributeValue.{LongValue, StringValue}
-import trace4cats.model.SemanticAttributeKeys.*
 import trace4cats.model.{AttributeValue, SpanKind, SpanStatus}
 import trace4cats.{ErrorHandler, ToHeaders}
 import zio.*
@@ -49,6 +48,7 @@ object ZioHttpServerTracer {
                       else ZIOAspect.identity
 
                     enrichSpanFromRequest(request, dropHeadersWhen, span) *>
+                      span.put(OtelSemconv.HttpRoute, AttributeValue.StringValue(nameOfSpan)).when(span.isSampled) *>
                       // NOTE: We need to call handler.runZIO and have the code executed within our span for propagation to take place
                       (h.runZIO(request) @@ logTraceContext).onExit {
                         case Exit.Success(response) => enrichSpanFromResponse(response, dropHeadersWhen, span)
@@ -121,20 +121,22 @@ object ZioHttpServerTracer {
     dropHeadersWhen: String => Boolean
   ): Chunk[(String, AttributeValue)] =
     Chunk[(String, AttributeValue)](
-      httpFlavor -> renderHttpVersion(req.version),
-      httpMethod -> req.method.toString(),
-      httpUrl    -> req.url.path.toString
-    ) ++ headerFields(headers = req.headers, `type` = "req", dropWhen = dropHeadersWhen) ++
-      req.url.host.map(host => serviceHostname -> StringValue(host)) ++
-      req.url.port.map(port => servicePort -> LongValue(port.toLong))
+      OtelSemconv.NetworkProtocolVersion -> renderHttpVersion(req.version),
+      OtelSemconv.HttpRequestMethod      -> req.method.toString,
+      OtelSemconv.UrlPath                -> req.url.path.toString
+    ) ++ 
+    req.url.scheme.map(scheme => OtelSemconv.UrlScheme  -> StringValue(scheme.encode)) ++
+    headerFields(headers = req.headers, `type` = "request", dropWhen = dropHeadersWhen) ++
+      req.url.host.map(host => OtelSemconv.ServerAddress -> StringValue(host)) ++
+      req.url.port.map(port => OtelSemconv.ServerPort -> LongValue(port.toLong))
 
   private def responseFields(
     resp: Response,
     dropHeadersWhen: String => Boolean
   ): List[(String, AttributeValue)] =
-    List[(String, AttributeValue)](httpStatusCode -> resp.status.code) ++ headerFields(
+    List[(String, AttributeValue)](OtelSemconv.HttpResponseStatusCode -> resp.status.code) ++ headerFields(
       resp.headers,
-      "resp",
+      "response",
       dropHeadersWhen
     )
 
@@ -145,7 +147,9 @@ object ZioHttpServerTracer {
   ): Chunk[(String, AttributeValue)] =
     Chunk.fromIterable(headers.collect {
       case header if !dropWhen(header.headerName) =>
-        s"${`type`}.header.${header.headerName}" -> AttributeValue.stringToTraceValue(header.renderedValue)
+        s"http.${`type`}.header.${header.headerName.toLowerCase}" -> AttributeValue.stringToTraceValue(
+          header.renderedValue
+        )
     })
 
   private val SensitiveHeaders: Set[String] = Set(
@@ -154,14 +158,10 @@ object ZioHttpServerTracer {
     Header.SetCookie
   ).map(_.name)
 
-  private def renderHttpVersion(in: Version): String = {
-    val http = "HTTP"
-    val version =
-      in match {
-        case Version.Default  => "Default"
-        case Version.Http_1_0 => "1.0"
-        case Version.Http_1_1 => "1.1"
-      }
-    s"$http/$version"
-  }
+  private def renderHttpVersion(in: Version): String =
+    in match {
+      case Version.Default  => "1.1"
+      case Version.Http_1_0 => "1.0"
+      case Version.Http_1_1 => "1.1"
+    }
 }

--- a/zio-http/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/ZioHttpServerTracerSpec.scala
+++ b/zio-http/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/ZioHttpServerTracerSpec.scala
@@ -53,7 +53,7 @@ object ZioHttpServerTracerSpec extends ZIOSpecDefault {
           } yield assertTrue(
             responseStatus == Status.Ok,
             spans.length == 2,
-            httpSpan.attributes.contains(s"resp.header.$customHeaderName"),
+            httpSpan.attributes.contains(s"http.response.header.${customHeaderName.toLowerCase}"),
             parentSpanIdOfFetch == spanIdOfHttp
           )
         } +

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
@@ -86,15 +86,18 @@ object KafkaConsumerTracer {
             OtelSemconv.MessagingOperationType          -> AttributeValue.StringValue("process"),
             OtelSemconv.MessagingDestinationName        -> consumerRecord.topic(),
             OtelSemconv.MessagingDestinationPartitionId -> consumerRecord.partition().toString,
-            OtelSemconv.MessagingKafkaOffset            -> consumerRecord.offset(),
-            OtelSemconv.MessagingKafkaMessageKey        -> consumerRecord.key().toString
+            OtelSemconv.MessagingKafkaOffset            -> consumerRecord.offset()
           )
+        val optionals: Map[String, AttributeValue] =
+          Option(consumerRecord.key)
+            .map(k => OtelSemconv.MessagingKafkaMessageKey -> AttributeValue.StringValue(k.toString)).toMap
+        val attributes = coreAttributes ++ optionals
         val logAspect =
-          if (enrichLogs) ZIOAspect.annotated(coreAttributes.map { case (k, v) => (k, v.toString) }.toSeq*)
+          if (enrichLogs) ZIOAspect.annotated(attributes.map { case (k, v) => (k, v.toString) }.toSeq*)
           else ZIOAspect.identity
 
         tracer.fromHeaders(headers = traceHeaders, name = "kafka-consume-with", kind = SpanKind.Consumer) { span =>
-          span.putAll(coreAttributes) *> f(consumerRecord) @@ logAspect
+          span.putAll(attributes) *> f(consumerRecord) @@ logAspect
         }
     }
 }

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
@@ -38,12 +38,14 @@ object KafkaConsumerTracer {
 
           val coreAttributes: Map[String, AttributeValue] =
             Map(
-              "consumer.group" -> group,
-              "topic"          -> topic,
-              "partition"      -> partition,
-              "offset"         -> offset,
-              "timestamp"      -> timestamp,
-              "timestamp.type" -> record.timestampType().name
+              OtelSemconv.MessagingSystem                 -> "kafka",
+              OtelSemconv.MessagingOperationType          -> "process",
+              OtelSemconv.MessagingDestinationName        -> topic,
+              OtelSemconv.MessagingConsumerGroupName      -> group,
+              OtelSemconv.MessagingDestinationPartitionId -> partition.toString,
+              OtelSemconv.MessagingKafkaOffset            -> offset,
+              "messaging.kafka.message.timestamp"         -> timestamp,
+              "messaging.kafka.message.timestamp.type"    -> record.timestampType().name
             )
 
           span
@@ -80,12 +82,12 @@ object KafkaConsumerTracer {
         val traceHeaders = extractConsumerRecordTraceHeaders(consumerRecord)
         val coreAttributes: Map[String, AttributeValue] =
           Map(
-            "kafka.topic"           -> consumerRecord.topic(),
-            "kafka.partition"       -> consumerRecord.partition(),
-            "kafka.offset"          -> consumerRecord.offset(),
-            "kafka.create.time"     -> consumerRecord.timestamp(),
-            "kafka.log.append.time" -> consumerRecord.timestamp(),
-            "kafka.key"             -> consumerRecord.key().toString()
+            OtelSemconv.MessagingSystem                 -> AttributeValue.StringValue("kafka"),
+            OtelSemconv.MessagingOperationType          -> AttributeValue.StringValue("process"),
+            OtelSemconv.MessagingDestinationName        -> consumerRecord.topic(),
+            OtelSemconv.MessagingDestinationPartitionId -> consumerRecord.partition().toString,
+            OtelSemconv.MessagingKafkaOffset            -> consumerRecord.offset(),
+            OtelSemconv.MessagingKafkaMessageKey        -> consumerRecord.key().toString
           )
         val logAspect =
           if (enrichLogs) ZIOAspect.annotated(coreAttributes.map { case (k, v) => (k, v.toString) }.toSeq*)

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaProducerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaProducerTracer.scala
@@ -180,7 +180,6 @@ object KafkaProducerTracer {
             OtelSemconv.MessagingOperationType   -> AttributeValue.StringValue("send"),
             OtelSemconv.MessagingDestinationName -> AttributeValue.StringList(topics.distinct)
           )
-          .ignoreLogged
       )
 
   private def enrichRecordsWithTraceHeaders[K, V](

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaProducerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaProducerTracer.scala
@@ -1,7 +1,7 @@
 package io.kaizensolutions.trace4cats.zio.extras.ziokafka
 
 import cats.data.NonEmptyList
-import io.kaizensolutions.trace4cats.zio.extras.{ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
 import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.apache.kafka.common.{Metric, MetricName, PartitionInfo}
@@ -173,7 +173,15 @@ object KafkaProducerTracer {
   private def enrichSpanWithTopics[K, V](records: Chunk[ProducerRecord[K, V]], span: ZSpan): UIO[Unit] =
     NonEmptyList
       .fromList(records.map(_.topic()).toList)
-      .fold(ifEmpty = ZIO.unit)(topics => span.put("topics", AttributeValue.StringList(topics.distinct)).ignoreLogged)
+      .fold(ifEmpty = ZIO.unit)(topics =>
+        span
+          .putAll(
+            OtelSemconv.MessagingSystem          -> AttributeValue.StringValue("kafka"),
+            OtelSemconv.MessagingOperationType   -> AttributeValue.StringValue("send"),
+            OtelSemconv.MessagingDestinationName -> AttributeValue.StringList(topics.distinct)
+          )
+          .ignoreLogged
+      )
 
   private def enrichRecordsWithTraceHeaders[K, V](
     headers: TraceHeaders,

--- a/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
+++ b/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
@@ -61,7 +61,7 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
             span.name == "kafka-producer-send-buffer" &&
               span.kind == SpanKind.Producer &&
               span.attributes.exists { case (k, v) =>
-                k == "topics" &&
+                k == "messaging.destination.name" &&
                 v.value.value == NonEmptyList.of(topic)
               }
           ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized tracing span attributes across HTTP, Kafka, and database integrations to OpenTelemetry semantic-convention keys for URLs/routing, server address/port, response status, and messaging/database metadata.
  * Improved database tracing by including detected database system details in span attributes; refreshed Kafka producer/consumer enrichment and ack/error span metadata.
* **Tests**
  * Updated span assertion keys and expected values to match the new OpenTelemetry-style attribute names (including header, URL, and database attributes).
* **Chores**
  * Updated `.gitignore` for local tooling artifacts.
  * Adjusted SBT test settings for forked parallel execution and Zonky embedded Postgres binary path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->