### PR TITLE
Configurable parent-child relationship between producers and consumers

### DIFF
--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/SpanRelationship.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/SpanRelationship.scala
@@ -1,0 +1,22 @@
+package io.kaizensolutions.trace4cats.zio.extras
+
+/**
+ * Controls how a consumer span relates to the producer span whose context was
+ * propagated via message headers.
+ *
+ * In both modes, a [[trace4cats.model.Link]] to the producer span is always
+ * added to the consumer span.
+ *
+ *   - [[SpanRelationship.ParentChild]]: The consumer span is created as a child
+ *     of the producer's trace context (same trace ID). This ensures tail-based
+ *     samplers at the collector keep producer and consumer spans together.
+ *
+ *   - [[SpanRelationship.Link]]: The consumer span starts a new trace context
+ *     (per OTel messaging semconv) and only links back to the producer. Use
+ *     this when you want independent trace IDs for producer and consumer.
+ */
+sealed trait SpanRelationship extends Product with Serializable
+object SpanRelationship {
+  case object ParentChild extends SpanRelationship
+  case object Link        extends SpanRelationship
+}

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
@@ -3,7 +3,7 @@ package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka
 import cats.syntax.show.*
 import cats.syntax.foldable.*
 import fs2.kafka.{ConsumerRecord, Headers}
-import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, SpanRelationship, ZSpan, ZTracer}
 import trace4cats.ToHeaders
 import trace4cats.model.{AttributeValue, Link, SpanKind, TraceHeaders}
 import zio.{RIO, ZIO, ZIOAspect}
@@ -19,23 +19,24 @@ object KafkaConsumerTracer {
    * Wraps a function that processes a ConsumerRecord with a span. This is meant
    * for the FS2 Kafka consumeChunks API.
    *
-   * Per the OTel messaging semconv, the consumer "Process" span uses a link to
-   * the producer's creation context rather than a parent-child relationship.
-   *
-   * Note: commits are not traced here because they happen externally (e.g. via
-   * CommitNow in consumeChunk, or commitBatchWithin). This function only
-   * instruments the processing of individual records.
+   * A link to the producer's creation context is always added to the consumer
+   * span regardless of the chosen [[SpanRelationship]] mode.
    *
    * @param tracer
    * @param spanNamer
    *   function to derive the span name from the record (default: "process
    *   {topic}")
+   * @param spanRelationship
+   *   controls whether the consumer span is a child of the producer span
+   *   ([[SpanRelationship.ParentChild]]) or starts a new trace context
+   *   ([[SpanRelationship.Link]]). Default: ParentChild.
    * @param process
    * @return
    */
   def processSpannedConsumerRecord[R, K, V, Out](
     tracer: ZTracer,
-    spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V]
+    spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V],
+    spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   )(process: (ConsumerRecord[K, V], ZSpan) => RIO[R, Out]): ConsumerRecord[K, V] => RIO[R, Out] = {
     (record: ConsumerRecord[K, V]) =>
       val traceHeaders = extractTraceHeaders(record.headers)
@@ -56,21 +57,30 @@ object KafkaConsumerTracer {
           OtelSemconv.MessagingKafkaMessageKey        -> AttributeValue.StringValue(key)
         )
 
-      // Per semconv: consumer "Process" span links to the producer's creation context
-      // instead of using it as a parent. This preserves the consumer's own trace context.
+      // Always compute the link to the producer's creation context
       val producerLink = ToHeaders.standard.toContext(traceHeaders).map(ctx => Link(ctx.traceId, ctx.spanId))
 
-      tracer.withSpan(name = spanName, kind = SpanKind.Consumer) { span =>
+      def body(span: ZSpan): RIO[R, Out] = {
         val addLink = producerLink.fold(ZIO.unit)(span.addLink)
         addLink *> span.putAll(attributes) *> process(record, span)
-      } @@ ZIOAspect.annotated(attributes.view.mapValues(_.show).toSeq*)
+      }
+
+      val traced = spanRelationship match {
+        case SpanRelationship.ParentChild =>
+          tracer.fromHeaders(headers = traceHeaders, name = spanName, kind = SpanKind.Consumer)(body)
+        case SpanRelationship.Link =>
+          tracer.withSpan(name = spanName, kind = SpanKind.Consumer)(body)
+      }
+
+      traced @@ ZIOAspect.annotated(attributes.view.mapValues(_.show).toSeq*)
   }
 
   def processConsumerRecord[R, K, V, Out](
     tracer: ZTracer,
-    spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V]
+    spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V],
+    spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   )(process: ConsumerRecord[K, V] => RIO[R, Out]): ConsumerRecord[K, V] => RIO[R, Out] =
-    processSpannedConsumerRecord(tracer, spanNamer)((record, _) => process(record))
+    processSpannedConsumerRecord(tracer, spanNamer, spanRelationship)((record, _) => process(record))
 
   private def extractTraceHeaders(in: Headers): TraceHeaders =
     in.toChain.foldMap(header => TraceHeaders.of(header.key() -> header.as[String]))

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/package.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/package.scala
@@ -4,16 +4,20 @@ import cats.syntax.all.*
 import fs2.Stream
 import fs2.kafka.*
 import fs2.kafka.consumer.KafkaConsumeChunk.CommitNow
-import io.kaizensolutions.trace4cats.zio.extras.ZTracer
+import io.kaizensolutions.trace4cats.zio.extras.{SpanRelationship, ZTracer}
 import zio.interop.catz.*
 import zio.{RIO, ZIO}
 
 package object kafka {
   implicit class Fs2KafkaConsumerChunksOps[R <: ZTracer, K, V](val consumer: KafkaConsumer[RIO[R, *], K, V])
       extends AnyVal {
-    def tracedConsumeChunk(process: ConsumerRecord[K, V] => RIO[R, Any]) =
+    def tracedConsumeChunk(
+      process: ConsumerRecord[K, V] => RIO[R, Any],
+      spanRelationship: SpanRelationship = SpanRelationship.ParentChild
+    ) =
       ZIO.service[ZTracer].flatMap { tracer =>
-        val tracedProcess = KafkaConsumerTracer.processConsumerRecord(tracer)(process)
+        val tracedProcess =
+          KafkaConsumerTracer.processConsumerRecord(tracer, spanRelationship = spanRelationship)(process)
         consumer.consumeChunk(_.traverse_(tracedProcess).as(CommitNow))
       }
   }
@@ -21,9 +25,13 @@ package object kafka {
   implicit class Fs2StreamKafkaConsumerChunksOps[R <: ZTracer, K, V](
     val consumer: Stream[RIO[R, *], KafkaConsumer[RIO[R, *], K, V]]
   ) extends AnyVal {
-    def tracedConsumeChunk(process: ConsumerRecord[K, V] => RIO[R, Any]) =
+    def tracedConsumeChunk(
+      process: ConsumerRecord[K, V] => RIO[R, Any],
+      spanRelationship: SpanRelationship = SpanRelationship.ParentChild
+    ) =
       ZIO.service[ZTracer].flatMap { tracer =>
-        val tracedProcess = KafkaConsumerTracer.processConsumerRecord(tracer)(process)
+        val tracedProcess =
+          KafkaConsumerTracer.processConsumerRecord(tracer, spanRelationship = spanRelationship)(process)
         consumer.consumeChunk(_.traverse_(tracedProcess).as(CommitNow))
       }
   }
@@ -31,11 +39,12 @@ package object kafka {
   implicit class Fs2KafkaConsumerOps[R, K, V](val self: KafkaConsumer[RIO[R, *], K, V]) extends AnyVal {
     def consumeChunkTraced(
       ztracer: ZTracer,
-      spanNamer: KafkaConsumerTracer.SpanNamer[K, V] = KafkaConsumerTracer.SpanNamer.default[K, V]
+      spanNamer: KafkaConsumerTracer.SpanNamer[K, V] = KafkaConsumerTracer.SpanNamer.default[K, V],
+      spanRelationship: SpanRelationship = SpanRelationship.ParentChild
     )(
       process: ConsumerRecord[K, V] => RIO[R, Unit]
     ): RIO[R, Nothing] = {
-      val tracedProcess = KafkaConsumerTracer.processConsumerRecord(ztracer, spanNamer)(process)
+      val tracedProcess = KafkaConsumerTracer.processConsumerRecord(ztracer, spanNamer, spanRelationship)(process)
       self.consumeChunk(_.traverse(tracedProcess).as(CommitNow))
     }
   }

--- a/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
+++ b/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.implicits.toShow
 import fs2.kafka.*
 import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
-import io.kaizensolutions.trace4cats.zio.extras.{InMemorySpanCompleter, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{InMemorySpanCompleter, SpanRelationship, ZTracer}
 import trace4cats.model.SpanKind
 import zio.interop.catz.*
 import zio.logging.backend.SLF4J
@@ -82,7 +82,7 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
       }
     ),
     suite("Consumer")(
-      test("Links to producer trace context") {
+      test("ParentChild mode: consumer span is child of producer (same trace ID) and links to producer") {
         val topic = UUID.randomUUID().toString
         ZIO.scoped(
           for {
@@ -91,16 +91,26 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
             consumer <- ZIO.service[Consumer]
             p        <- Promise.make[Nothing, Unit]
             _        <- consumer.subscribeTo(topic)
-            _        <- consumer.consumeChunkTraced(tracer)(_ => p.succeed(()).unit).forkScoped
+            _ <- consumer
+                   .consumeChunkTraced(tracer, spanRelationship = SpanRelationship.ParentChild)(_ => p.succeed(()).unit)
+                   .forkScoped
 
             _     <- producer.produceOne(topic, "key", "value")
             _     <- p.await
             spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"process $topic")))
           } yield assertTrue(
-            // Consumer process span links to producer
+            // Consumer span shares the same trace ID as producer span (parent-child)
             spans.exists(consumerSpan =>
               consumerSpan.name == s"process $topic" &&
                 consumerSpan.kind == SpanKind.Consumer &&
+                spans.exists(producerSpan =>
+                  producerSpan.kind == SpanKind.Producer &&
+                    consumerSpan.context.traceId.show == producerSpan.context.traceId.show
+                )
+            ),
+            // Link is still added
+            spans.exists(consumerSpan =>
+              consumerSpan.name == s"process $topic" &&
                 consumerSpan.links.exists(links =>
                   links.exists(link =>
                     spans.exists(producerSpan =>
@@ -113,7 +123,48 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
             )
           )
         )
+      },
+      test("Link mode: consumer span has different trace ID and links to producer") {
+        val topic = UUID.randomUUID().toString
+        ZIO.scoped(
+          for {
+            tracer   <- ZIO.service[ZTracer]
+            producer <- ZIO.service[Producer]
+            consumer <- ZIO.service[Consumer]
+            p        <- Promise.make[Nothing, Unit]
+            _        <- consumer.subscribeTo(topic)
+            _ <- consumer
+                   .consumeChunkTraced(tracer, spanRelationship = SpanRelationship.Link)(_ => p.succeed(()).unit)
+                   .forkScoped
 
+            _     <- producer.produceOne(topic, "key", "value")
+            _     <- p.await
+            spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"process $topic")))
+          } yield assertTrue(
+            // Consumer span has a different trace ID than producer span
+            spans.exists(consumerSpan =>
+              consumerSpan.name == s"process $topic" &&
+                consumerSpan.kind == SpanKind.Consumer &&
+                spans.exists(producerSpan =>
+                  producerSpan.kind == SpanKind.Producer &&
+                    consumerSpan.context.traceId.show != producerSpan.context.traceId.show
+                )
+            ),
+            // Link is still added
+            spans.exists(consumerSpan =>
+              consumerSpan.name == s"process $topic" &&
+                consumerSpan.links.exists(links =>
+                  links.exists(link =>
+                    spans.exists(producerSpan =>
+                      producerSpan.kind == SpanKind.Producer &&
+                        link.traceId.show == producerSpan.context.traceId.show &&
+                        link.spanId.show == producerSpan.context.spanId.show
+                    )
+                  )
+                )
+            )
+          )
+        )
       },
       test("Experiences no lag after processing all elements") {
         val topic = UUID.randomUUID().toString

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
@@ -20,54 +20,29 @@ object KafkaConsumerTracer {
     tracer: ZTracer,
     stream: ZStream[R, Throwable, CommittableRecord[K, V]],
     spanNameForElement: SpanNamer[K, V] = SpanNamer.default[K, V],
-    enrichLogs: Boolean = true
+    enrichLogs: Boolean = true,
+    spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   ): ZStream[R, Throwable, Spanned[CommittableRecord[K, V]]] =
     stream.mapChunksZIO(_.mapZIO { comm =>
       val traceHeaders = extractTraceHeaders(comm)
       val spanName     = spanNameForElement(comm)
+      val record       = comm.record
+      val topic        = record.topic
 
-      // Per semconv: consumer "Process" span links to the producer's creation context
-      // instead of using it as a parent.
-      val producerLink =
-        ToHeaders.standard.toContext(traceHeaders).map(ctx => trace4cats.model.Link(ctx.traceId, ctx.spanId))
+      val attributes = coreAttributes(topic, record.partition, comm.offset.offset, Option(record.key).map(_.toString))
 
-      tracer.withSpan(name = spanName, kind = SpanKind.Consumer) { span =>
-        val addLink = producerLink.fold(ZIO.unit)(span.addLink)
-
-        val record    = comm.record
-        val topic     = record.topic
-        val partition = record.partition
-        val offset    = comm.offset.offset
-        val group     = comm.offset.consumerGroupMetadata.map(_.groupId()).getOrElse("Unknown")
-        val timestamp = record.timestamp
-
-        val coreAttributes: Map[String, AttributeValue] =
-          Map(
-            OtelSemconv.MessagingSystem                 -> "kafka",
-            OtelSemconv.MessagingOperationType          -> "process",
-            OtelSemconv.MessagingOperationName          -> "process",
-            OtelSemconv.MessagingDestinationName        -> topic,
-            OtelSemconv.MessagingConsumerGroupName      -> group,
-            OtelSemconv.MessagingDestinationPartitionId -> partition.toString,
-            OtelSemconv.MessagingKafkaOffset            -> offset,
-            "messaging.kafka.message.timestamp"         -> timestamp,
-            "messaging.kafka.message.timestamp.type"    -> record.timestampType().name
-          )
-
+      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes) { span =>
         val enrichedComm = comm.copy(
           commitHandle = _ =>
-            // The outer span may be closed so to be safe, we extract the ID and use it to create a sub-span for the commit
             tracer.fromHeaders(
               headers = ToHeaders.standard.fromContext(span.context),
-              name = s"commit ${topic}",
+              name = s"commit $topic",
               kind = SpanKind.Client
             ) { commitSpan =>
-              commitSpan.putAll(coreAttributes) *> comm.offset.commit
+              commitSpan.putAll(attributes) *> comm.offset.commit
             }
         )
-
-        addLink *> span.putAll(coreAttributes) *>
-          ZIO.succeed(Spanned(span.extractHeaders(ToHeaders.all), enrichedComm, enrichLogs))
+        ZIO.succeed(Spanned(span.extractHeaders(ToHeaders.all), enrichedComm, enrichLogs))
       }
     })
 
@@ -78,37 +53,66 @@ object KafkaConsumerTracer {
     keyDeserializer: Deserializer[R, K],
     valueDeserializer: Deserializer[R, V],
     commitRetryPolicy: Schedule[Any, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3),
-    enrichLogs: Boolean = true
+    enrichLogs: Boolean = true,
+    spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   )(f: KafkaConsumerRecord[K, V] => URIO[R1, Unit]): RIO[R & R1, Unit] =
     consumer.consumeWith[R, R1, K, V](subscription, keyDeserializer, valueDeserializer, commitRetryPolicy) {
       consumerRecord =>
         val traceHeaders = extractConsumerRecordTraceHeaders(consumerRecord)
-        val coreAttributes: Map[String, AttributeValue] =
-          Map(
-            OtelSemconv.MessagingSystem                 -> AttributeValue.StringValue("kafka"),
-            OtelSemconv.MessagingOperationType          -> AttributeValue.StringValue("process"),
-            OtelSemconv.MessagingOperationName          -> AttributeValue.StringValue("process"),
-            OtelSemconv.MessagingDestinationName        -> consumerRecord.topic(),
-            OtelSemconv.MessagingDestinationPartitionId -> consumerRecord.partition().toString,
-            OtelSemconv.MessagingKafkaOffset            -> consumerRecord.offset()
-          )
-        val optionals: Map[String, AttributeValue] =
-          Option(consumerRecord.key)
-            .map(k => OtelSemconv.MessagingKafkaMessageKey -> AttributeValue.StringValue(k.toString))
-            .toMap
-        val attributes = coreAttributes ++ optionals
+        val spanName     = s"process ${consumerRecord.topic()}"
+        val attributes = coreAttributes(
+          consumerRecord.topic(),
+          consumerRecord.partition(),
+          consumerRecord.offset(),
+          Option(consumerRecord.key).map(_.toString)
+        )
+
         val logAspect =
           if (enrichLogs) ZIOAspect.annotated(attributes.map { case (k, v) => (k, v.toString) }.toSeq*)
           else ZIOAspect.identity
 
-        // Per semconv: consumer "Process" span links to the producer's creation context
-        // instead of using it as a parent.
-        val producerLink =
-          ToHeaders.standard.toContext(traceHeaders).map(ctx => trace4cats.model.Link(ctx.traceId, ctx.spanId))
-
-        tracer.withSpan(name = s"process ${consumerRecord.topic()}", kind = SpanKind.Consumer) { span =>
-          val addLink = producerLink.fold(ZIO.unit)(span.addLink)
-          addLink *> span.putAll(attributes) *> f(consumerRecord) @@ logAspect
+        withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes) { _ =>
+          f(consumerRecord) @@ logAspect
         }
     }
+
+  private def coreAttributes(
+    topic: String,
+    partition: Int,
+    offset: Long,
+    key: Option[String]
+  ): Map[String, AttributeValue] = {
+    val base: Map[String, AttributeValue] = Map(
+      OtelSemconv.MessagingSystem                 -> AttributeValue.StringValue("kafka"),
+      OtelSemconv.MessagingOperationType          -> AttributeValue.StringValue("process"),
+      OtelSemconv.MessagingOperationName          -> AttributeValue.StringValue("process"),
+      OtelSemconv.MessagingDestinationName        -> AttributeValue.StringValue(topic),
+      OtelSemconv.MessagingDestinationPartitionId -> AttributeValue.StringValue(partition.toString),
+      OtelSemconv.MessagingKafkaOffset            -> AttributeValue.LongValue(offset)
+    )
+    key.fold(base)(k => base + (OtelSemconv.MessagingKafkaMessageKey -> AttributeValue.StringValue(k)))
+  }
+
+  private def withConsumerSpan[R, A](
+    tracer: ZTracer,
+    traceHeaders: trace4cats.model.TraceHeaders,
+    spanName: String,
+    spanRelationship: SpanRelationship,
+    attributes: Map[String, AttributeValue]
+  )(body: ZSpan => ZIO[R, Nothing, A]): ZIO[R, Nothing, A] = {
+    val producerLink =
+      ToHeaders.standard.toContext(traceHeaders).map(ctx => trace4cats.model.Link(ctx.traceId, ctx.spanId))
+
+    def run(span: ZSpan): ZIO[R, Nothing, A] = {
+      val addLink = producerLink.fold(ZIO.unit)(span.addLink)
+      addLink *> span.putAll(attributes) *> body(span)
+    }
+
+    spanRelationship match {
+      case SpanRelationship.ParentChild =>
+        tracer.fromHeaders(headers = traceHeaders, name = spanName, kind = SpanKind.Consumer)(run)
+      case SpanRelationship.Link =>
+        tracer.withSpan(name = spanName, kind = SpanKind.Consumer)(run)
+    }
+  }
 }

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/package.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/package.scala
@@ -19,7 +19,8 @@ package object ziokafka {
       keyDeserializer: Deserializer[R, K],
       valueDeserializer: Deserializer[R, V],
       commitRetryPolicy: Schedule[Any, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3),
-      enrichLogs: Boolean = true
+      enrichLogs: Boolean = true,
+      spanRelationship: SpanRelationship = SpanRelationship.ParentChild
     )(f: KafkaConsumerRecord[K, V] => URIO[R1, Unit]): RIO[R & R1 & ZTracer, Unit] =
       ZIO.serviceWithZIO[ZTracer] { tracer =>
         KafkaConsumerTracer.tracedConsumeWith[R, R1, K, V](
@@ -29,7 +30,8 @@ package object ziokafka {
           keyDeserializer,
           valueDeserializer,
           commitRetryPolicy,
-          enrichLogs
+          enrichLogs,
+          spanRelationship
         )(f)
       }
   }

--- a/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
+++ b/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
@@ -70,7 +70,7 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
       }
     ),
     suite("Consumer")(
-      test("Links to producer trace context") {
+      test("ParentChild mode: consumer span is child of producer (same trace ID) and links to producer") {
         val topic = UUID.randomUUID().toString
         for {
           tracer   <- ZIO.service[ZTracer]
@@ -80,7 +80,8 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
           _ <- KafkaConsumerTracer
                  .traceConsumerStream(
                    tracer,
-                   consumer.plainStream(Subscription.topics(topic), Serde.string, Serde.string)
+                   consumer.plainStream(Subscription.topics(topic), Serde.string, Serde.string),
+                   spanRelationship = SpanRelationship.ParentChild
                  )
                  .endTracingEachElement
                  .tap(_.offset.commit)
@@ -92,7 +93,15 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
           _     <- p.await
           spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"commit $topic")))
         } yield assertTrue(
-          // Consumer process span links to producer
+          // Consumer span shares the same trace ID as producer span (parent-child)
+          spans.exists(consumerSpan =>
+            consumerSpan.name == s"process $topic" &&
+              spans.exists(producerSpan =>
+                producerSpan.kind == SpanKind.Producer &&
+                  consumerSpan.context.traceId.show == producerSpan.context.traceId.show
+              )
+          ),
+          // Link is still added
           spans.exists(consumerSpan =>
             consumerSpan.name == s"process $topic" &&
               consumerSpan.links.exists(links =>
@@ -115,7 +124,53 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
           )
         )
       },
-      test("Consume chunks links to producer trace context") {
+      test("Link mode: consumer span has different trace ID and links to producer") {
+        val topic = UUID.randomUUID().toString
+        for {
+          tracer   <- ZIO.service[ZTracer]
+          p        <- Promise.make[Nothing, Unit]
+          consumer <- ZIO.service[Consumer]
+          producer <- ZIO.service[Producer]
+          _ <- KafkaConsumerTracer
+                 .traceConsumerStream(
+                   tracer,
+                   consumer.plainStream(Subscription.topics(topic), Serde.string, Serde.string),
+                   spanRelationship = SpanRelationship.Link
+                 )
+                 .endTracingEachElement
+                 .tap(_.offset.commit)
+                 .tap(_ => p.succeed(()))
+                 .runDrain
+                 .forkScoped
+
+          _     <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
+          _     <- p.await
+          spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"commit $topic")))
+        } yield assertTrue(
+          // Consumer span has a different trace ID than producer span
+          spans.exists(consumerSpan =>
+            consumerSpan.name == s"process $topic" &&
+              spans.exists(producerSpan =>
+                producerSpan.kind == SpanKind.Producer &&
+                  consumerSpan.context.traceId.show != producerSpan.context.traceId.show
+              )
+          ),
+          // Link is still added
+          spans.exists(consumerSpan =>
+            consumerSpan.name == s"process $topic" &&
+              consumerSpan.links.exists(links =>
+                links.exists(link =>
+                  spans.exists(producerSpan =>
+                    producerSpan.kind == SpanKind.Producer &&
+                      link.traceId.show == producerSpan.context.traceId.show &&
+                      link.spanId.show == producerSpan.context.spanId.show
+                  )
+                )
+              )
+          )
+        )
+      },
+      test("ParentChild mode with tracedConsumeWith: consumer span is child of producer and links to producer") {
         val topic = UUID.randomUUID().toString
         for {
           tracer   <- ZIO.service[ZTracer]
@@ -124,15 +179,75 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
           producer <- ZIO.service[Producer]
           fiber <-
             KafkaConsumerTracer
-              .tracedConsumeWith(tracer, consumer, Subscription.topics(topic), Serde.string, Serde.string)(_ =>
-                p.succeed(()).unit
-              )
+              .tracedConsumeWith(
+                tracer,
+                consumer,
+                Subscription.topics(topic),
+                Serde.string,
+                Serde.string,
+                spanRelationship = SpanRelationship.ParentChild
+              )(_ => p.succeed(()).unit)
               .forkScoped
           _     <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
           _     <- p.await
           _     <- fiber.interrupt
           spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.retrieveCollected)
         } yield assertTrue(
+          // Consumer span shares the same trace ID as producer span
+          spans.exists(consumerSpan =>
+            consumerSpan.name == s"process $topic" &&
+              spans.exists(producerSpan =>
+                producerSpan.kind == SpanKind.Producer &&
+                  consumerSpan.context.traceId.show == producerSpan.context.traceId.show
+              )
+          ),
+          // Link is still added
+          spans.exists(consumerSpan =>
+            consumerSpan.name == s"process $topic" &&
+              consumerSpan.links.exists(links =>
+                links.exists(link =>
+                  spans.exists(producerSpan =>
+                    producerSpan.kind == SpanKind.Producer &&
+                      link.traceId.show == producerSpan.context.traceId.show &&
+                      link.spanId.show == producerSpan.context.spanId.show
+                  )
+                )
+              )
+          )
+        )
+      },
+      test("Link mode with tracedConsumeWith: consumer span has different trace ID and links to producer") {
+        val topic = UUID.randomUUID().toString
+        for {
+          tracer   <- ZIO.service[ZTracer]
+          p        <- Promise.make[Nothing, Unit]
+          consumer <- ZIO.service[Consumer]
+          producer <- ZIO.service[Producer]
+          fiber <-
+            KafkaConsumerTracer
+              .tracedConsumeWith(
+                tracer,
+                consumer,
+                Subscription.topics(topic),
+                Serde.string,
+                Serde.string,
+                spanRelationship = SpanRelationship.Link
+              )(_ => p.succeed(()).unit)
+              .forkScoped
+          _     <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
+          _     <- p.await
+          _     <- fiber.interrupt
+          spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.retrieveCollected)
+        } yield assertTrue(
+          // Consumer span has a different trace ID than producer span
+          spans.exists(consumerSpan =>
+            consumerSpan.name == s"process $topic" &&
+              spans.exists(producerSpan =>
+                producerSpan.kind == SpanKind.Producer &&
+                  consumerSpan.context.traceId.show != producerSpan.context.traceId.show
+              )
+          ),
+          // Link is still added
           spans.exists(consumerSpan =>
             consumerSpan.name == s"process $topic" &&
               consumerSpan.links.exists(links =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kafka consumer span relationships: parent-child or linked spans.
  * Producer links are preserved in both tracing modes.
  * Added relationship configuration to Kafka tracing helpers, defaulting to parent-child behavior.
  * Standardized consumer span attributes, including message keys.

* **Bug Fixes**
  * Improved consistency of Kafka consumer tracing across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->