### PR TITLE
Log context injection at the tracer level

### DIFF
--- a/.sbtrc
+++ b/.sbtrc
@@ -1,0 +1,2 @@
+alias fmt = scalafmtAll; scalafmtSbt
+alias lint = scalafmtCheckAll; scalafmtSbtCheck; doc; mdoc

--- a/aliases.sbt
+++ b/aliases.sbt
@@ -1,2 +1,0 @@
-addCommandAlias("lint", "; scalafmtAll")
-addCommandAlias("lintEnforce", "; scalafmtCheckAll; mdoc")

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/KafkaLogAnnotations.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/KafkaLogAnnotations.scala
@@ -1,0 +1,36 @@
+package io.kaizensolutions.trace4cats.zio.extras
+
+import trace4cats.model.AttributeValue
+import zio.LogAnnotation
+
+/**
+ * Controls which span attributes from Kafka consumer tracing are surfaced as
+ * ZIO log annotations. The default includes only the attributes useful for
+ * correlating logs to a specific message: topic, partition, offset, and key.
+ */
+trait KafkaLogAnnotations {
+  def apply(attributes: Map[String, AttributeValue]): Set[LogAnnotation]
+}
+
+object KafkaLogAnnotations {
+
+  /** Logs topic, partition, offset, and message key. */
+  val default: KafkaLogAnnotations = (attributes: Map[String, AttributeValue]) => {
+    val keys = Set(
+      OtelSemconv.MessagingDestinationName,
+      OtelSemconv.MessagingDestinationPartitionId,
+      OtelSemconv.MessagingKafkaOffset,
+      OtelSemconv.MessagingKafkaMessageKey
+    )
+    attributes.collect {
+      case (k, v) if keys.contains(k) => LogAnnotation(k, v.toString)
+    }.toSet
+  }
+
+  /** Logs all span attributes as log annotations. */
+  val all: KafkaLogAnnotations = (attributes: Map[String, AttributeValue]) =>
+    attributes.map { case (k, v) => LogAnnotation(k, v.toString) }.toSet
+
+  /** No log annotations from span attributes. */
+  val none: KafkaLogAnnotations = _ => Set.empty
+}

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/LogContextExtractor.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/LogContextExtractor.scala
@@ -1,0 +1,28 @@
+package io.kaizensolutions.trace4cats.zio.extras
+
+import cats.Show
+import trace4cats.model.{SpanContext, SpanId, TraceId}
+import zio.{LogAnnotation, ZIO}
+
+trait LogContextExtractor {
+  def apply(spanContext: SpanContext): Set[LogAnnotation]
+
+  def enrichLogs[R, E, A](spanContext: SpanContext)(fa: ZIO[R, E, A]): ZIO[R, E, A] =
+    ZIO.logAnnotate(apply(spanContext))(fa)
+}
+
+object LogContextExtractor {
+
+  /**
+   * The default extractor creates logs that are compatible with Opentelemetry
+   * @see
+   *   [[https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/]]
+   */
+  def default: LogContextExtractor = (spanContext: SpanContext) =>
+    Set(
+      LogAnnotation("trace_id", Show[TraceId].show(spanContext.traceId)),
+      LogAnnotation("span_id", Show[SpanId].show(spanContext.spanId))
+    )
+
+  val none: LogContextExtractor = _ => Set.empty
+}

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/SpanRelationship.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/SpanRelationship.scala
@@ -4,8 +4,8 @@ package io.kaizensolutions.trace4cats.zio.extras
  * Controls how a consumer span relates to the producer span whose context was
  * propagated via message headers.
  *
- * In both modes, a `trace4cats.model.Link` to the producer span is always
- * added to the consumer span.
+ * In both modes, a `trace4cats.model.Link` to the producer span is always added
+ * to the consumer span.
  *
  *   - `SpanRelationship.ParentChild`: The consumer span is created as a child
  *     of the producer's trace context (same trace ID). This ensures tail-based

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/Spanned.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/Spanned.scala
@@ -10,12 +10,10 @@ import zio.ZIO
  *   is the span that is attached to the element.
  * @param value
  *   is the element that is being traced.
- * @param enrichLogs
- *   whether to enrich the logs with the span context
  * @tparam A
  *   is the element type that is being traced.
  */
-final case class Spanned[+A](headers: TraceHeaders, value: A, enrichLogs: Boolean = true) {
+final case class Spanned[+A](headers: TraceHeaders, value: A) {
   def map[B](f: A => B): Spanned[B] =
     copy(value = f(value))
 
@@ -23,21 +21,15 @@ final case class Spanned[+A](headers: TraceHeaders, value: A, enrichLogs: Boolea
     copy(value = b)
 
   def mapZIO[R, E, B](f: A => ZIO[R, E, B]): ZIO[R, E, Spanned[B]] =
-    f(value).map(b => copy(value = b)) @@ logAnnotateWithHeaders(headers, enrichLogs)
+    f(value).map(b => copy(value = b))
 
   def mapZIOTraced[R, E, B](name: String, kind: SpanKind = SpanKind.Internal)(
     f: A => ZIO[R, E, B]
   ): ZIO[R & ZTracer, E, Spanned[B]] =
-    ZTracer.fromHeaders(headers, name, kind)(_ => f(value).map(b => copy(value = b))) @@ logAnnotateWithHeaders(
-      headers,
-      enrichLogs
-    )
+    ZTracer.fromHeaders(headers, name, kind)(_ => f(value).map(b => copy(value = b)))
 
   def mapZIOWithTracer[R, E, B](tracer: ZTracer, name: String, kind: SpanKind = SpanKind.Internal)(
     f: A => ZIO[R, E, B]
   ): ZIO[R, E, Spanned[B]] =
-    tracer.fromHeaders(headers, name, kind)(_ => f(value).map(b => copy(value = b))) @@ logAnnotateWithHeaders(
-      headers,
-      enrichLogs
-    )
+    tracer.fromHeaders(headers, name, kind)(_ => f(value).map(b => copy(value = b)))
 }

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ZTracer.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ZTracer.scala
@@ -16,7 +16,8 @@ import zio.stream.ZStream
  */
 final class ZTracer private (
   private[extras] val current: FiberRef[ZSpan],
-  private[extras] val entryPoint: ZEntryPoint
+  private[extras] val entryPoint: ZEntryPoint,
+  private[extras] val logContextExtractor: LogContextExtractor
 ) { self =>
   def context: UIO[SpanContext] =
     current.get.map(_.context)
@@ -56,7 +57,11 @@ final class ZTracer private (
   )(fn: ZSpan => ZIO[R, E, A]): ZIO[R, E, A] =
     ZIO.scoped[R](
       fromHeadersScoped(headers, name, kind, errorHandler)
-        .flatMap(child => current.locally(child)(fn(child)))
+        .flatMap(child =>
+          current.locally(child)(
+            logContextExtractor.enrichLogs(child.context)(fn(child))
+          )
+        )
     )
 
   /**
@@ -96,7 +101,7 @@ final class ZTracer private (
   )(zio: ZIO[R, E, A])(implicit fileName: sourcecode.FileName, line: sourcecode.Line): ZIO[R, E, A] =
     ZIO.scoped[R] {
       spanScopedManual(s"${fileName.value}:${line.value}", kind)
-        .flatMap(span => current.locally(span)(zio))
+        .flatMap(span => current.locally(span)(logContextExtractor.enrichLogs(span.context)(zio)))
     }
 
   def span[R, E, A](
@@ -105,7 +110,9 @@ final class ZTracer private (
     errorHandler: ErrorHandler = ErrorHandler.empty
   )(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     ZIO.scoped[R] {
-      spanScopedManual(name, kind, errorHandler).flatMap(span => current.locally(span)(zio))
+      spanScopedManual(name, kind, errorHandler).flatMap(span =>
+        current.locally(span)(logContextExtractor.enrichLogs(span.context)(zio))
+      )
     }
 
   /**
@@ -197,8 +204,7 @@ final class ZTracer private (
     extractHeaders: O => TraceHeaders,
     extractName: O => String,
     kind: SpanKind = SpanKind.Internal,
-    errorHandler: ErrorHandler = ErrorHandler.empty,
-    enrichLogs: Boolean = true
+    errorHandler: ErrorHandler = ErrorHandler.empty
   )(stream: ZStream[R, E, O]): ZStream[R, E, Spanned[O]] =
     stream.mapChunksZIO(
       _.mapZIO(o =>
@@ -209,7 +215,7 @@ final class ZTracer private (
           errorHandler = errorHandler
         )(span =>
           // extract the child's span header so that all stream transformations are traced under the element
-          Exit.succeed(Spanned(span.extractHeaders(ToHeaders.all), o, enrichLogs))
+          Exit.succeed(Spanned(span.extractHeaders(ToHeaders.all), o))
         )
       )
     )
@@ -293,12 +299,14 @@ final class ZTracer private (
     errorHandler: ErrorHandler = ErrorHandler.empty
   )(fn: ZSpan => ZIO[R, E, A]): ZIO[R, E, A] =
     ZIO.scoped[R] {
-      spanScopedManual(name, kind, errorHandler).flatMap(span => current.locally(span)(fn(span)))
+      spanScopedManual(name, kind, errorHandler).flatMap(span =>
+        current.locally(span)(logContextExtractor.enrichLogs(span.context)(fn(span)))
+      )
     }
 }
 object ZTracer {
-  def make(current: FiberRef[ZSpan], entryPoint: ZEntryPoint): ZTracer =
-    new ZTracer(current, entryPoint)
+  def make(current: FiberRef[ZSpan], entryPoint: ZEntryPoint, logContextExtractor: LogContextExtractor): ZTracer =
+    new ZTracer(current, entryPoint, logContextExtractor)
 
   def span[R, E, A](
     name: String,
@@ -310,11 +318,10 @@ object ZTracer {
   def traceEachElement[R, E, O](
     extractName: O => String,
     kind: SpanKind = SpanKind.Internal,
-    errorHandler: ErrorHandler = ErrorHandler.empty,
-    enrichLogs: Boolean = true
+    errorHandler: ErrorHandler = ErrorHandler.empty
   )(stream: ZStream[R, E, O])(extractHeaders: O => TraceHeaders): ZStream[R & ZTracer, E, Spanned[O]] =
     ZStream.serviceWithStream[ZTracer](
-      _.traceEachElement(extractHeaders, extractName, kind, errorHandler, enrichLogs)(stream)
+      _.traceEachElement(extractHeaders, extractName, kind, errorHandler)(stream)
     )
 
   def traceEntireStream[R, E, O](
@@ -365,17 +372,19 @@ object ZTracer {
   )(zio: ZIO[R, E, A])(implicit fileName: sourcecode.FileName, line: sourcecode.Line): ZIO[R & ZTracer, E, A] =
     ZIO.serviceWithZIO[ZTracer](_.spanSource(kind)(zio)(fileName, line))
 
-  val layer: URLayer[ZEntryPoint, ZTracer] =
+  def layerWith(logContextExtractor: LogContextExtractor = LogContextExtractor.default): URLayer[ZEntryPoint, ZTracer] =
     ZLayer.scoped(
       for {
         ep      <- ZIO.service[ZEntryPoint]
         spanRef <- FiberRef.make[ZSpan](initial = ZSpan.noop)
-        tracer   = ZTracer.make(spanRef, ep)
+        tracer   = ZTracer.make(spanRef, ep, logContextExtractor)
       } yield tracer
     )
 
+  val layer: URLayer[ZEntryPoint, ZTracer] = layerWith()
+
   val noop: ZIO[Scope, Nothing, ZTracer] =
-    FiberRef.make[ZSpan](initial = ZSpan.noop).map(ref => ZTracer.make(ref, ZEntryPoint.noop))
+    FiberRef.make[ZSpan](initial = ZSpan.noop).map(ref => ZTracer.make(ref, ZEntryPoint.noop, LogContextExtractor.none))
 
   val noopLayer: ULayer[ZTracer] =
     ZLayer.scoped(noop)

--- a/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/package.scala
+++ b/core/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/package.scala
@@ -67,14 +67,4 @@ package object extras {
     def endTracingEachElement: ZStream[R, E, A] =
       s.mapChunks(_.map(s => s.value))
   }
-
-  def toAnnotations(headers: TraceHeaders): List[(String, String)] =
-    headers.values.collect { case (k, v) => k.toString -> v }.toList
-
-  type Aspect0 = ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any]
-
-  def logAnnotateWithHeaders(traceHeaders: TraceHeaders, enrich: Boolean): Aspect0 =
-    if (enrich)
-      ZIOAspect.annotated(toAnnotations(traceHeaders)*)
-    else ZIOAspect.identity
 }

--- a/core/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/InMemorySpanCompleter.scala
+++ b/core/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/InMemorySpanCompleter.scala
@@ -51,7 +51,7 @@ object InMemorySpanCompleter {
     val zep = new ZEntryPoint(in)
     FiberRef
       .make(ZSpan.noop)
-      .map(ZTracer.make(_, zep))
+      .map(ZTracer.make(_, zep, LogContextExtractor.default))
   }
 
   def layer(serviceName: String) =

--- a/docs/Integrations/HTTP/ziohttp.md
+++ b/docs/Integrations/HTTP/ziohttp.md
@@ -39,20 +39,22 @@ val http =
 val app: Routes[ZTracer, Nothing] =
   http.handleError(error => Response.text(error.getMessage).status(Status.InternalServerError))
 
-val tracedApp: Routes[ZTracer, Nothing] = app @@ trace(enrichLogs = true) // the tracing middleware
+val tracedApp: Routes[ZTracer, Nothing] = app @@ trace() // the tracing middleware
 ```
 
-Notice how `enrichLogs` is set to true, this will start augmenting the log context with trace header information. You 
-can also customize the trace headers and change the name of the span in order to reduce cardinality. 
+Log context enrichment (augmenting the log context with trace header information) is now configured at the `ZTracer` 
+level via `LogContextExtractor`. You can also customize the trace headers and change the name of the span in order to 
+reduce cardinality. 
 
 Here is an example of a trace when you hit the `/plaintext` endpoint:
 <img width="1114" alt="image" src="https://github.com/kaizen-solutions/trace4cats-zio-extras/assets/14280155/3ea7da5f-5ceb-43d5-a2d5-c51c88d776c9"></img>
 
-Accompanying this trace is the following log:
+Accompanying this trace is the following log (using `LogContextExtractor.default`, which adds OTel-compatible `trace_id` 
+and `span_id` annotations):
 ```
-10:39:57.712 [KQueueEventLoopGroup-2-2] [b3=5e66b278533ccb68db1610c56b464b31-3fd736b93350db66-1, X-B3-Sampled=1, X-B3-TraceId=5e66b278533ccb68db1610c56b464b31, X-B3-SpanId=3fd736b93350db66, traceparent=00-5e66b278533ccb68db1610c56b464b31-3fd736b93350db66-01] INFO  i.k.t.z.e.z.e.E.http - HELLO
+10:39:57.712 [KQueueEventLoopGroup-2-2] [trace_id=5e66b278533ccb68db1610c56b464b31, span_id=3fd736b93350db66] INFO  i.k.t.z.e.z.e.E.http - HELLO
 ```
-Notice how the log is enriched with the trace headers.
+Notice how the log is enriched with the trace context.
 
 ## Client
 We provide a traced client that calls out the zio-http client. It will automatically propagate the trace headers when making

--- a/docs/ztracer.md
+++ b/docs/ztracer.md
@@ -70,3 +70,33 @@ Running the stream above, we'd expect to see something along the lines of:
 ![Jaegar span](https://github.com/kaizen-solutions/trace4cats-zio-extras/assets/14280155/59ae4606-2728-4be2-b76c-367ecaff175c)
 
 Have a look at the [example](https://github.com/kaizen-solutions/trace4cats-zio-extras/blob/main/core-examples/src/main/scala/io/kaizensolutions/trace4cats/zio/core/examples/ExampleApp.scala) if you want to learn more.
+
+## Log Context Enrichment
+
+ZTracer automatically enriches the ZIO log context with trace information via `LogContextExtractor`. This means 
+any `ZIO.log*` calls within a traced span will include trace/span IDs in the log output without any additional 
+configuration.
+
+By default, `ZTracer.layer` uses `LogContextExtractor.default` which adds OpenTelemetry-compatible `trace_id` and 
+`span_id` annotations to the log context. You can customize this behavior when constructing the tracer layer:
+
+```scala mdoc:compile-only
+import io.kaizensolutions.trace4cats.zio.extras.{LogContextExtractor, ZTracer, ZEntryPoint}
+import cats.Show
+import trace4cats.model.{SpanContext, SpanId, TraceId}
+import zio.*
+
+// Use the default (OTel-compatible trace_id and span_id)
+val defaultLayer: URLayer[ZEntryPoint, ZTracer] = ZTracer.layer
+
+// Customize the log annotations
+val customLayer: URLayer[ZEntryPoint, ZTracer] = ZTracer.layerWith(
+  logContextExtractor = (spanContext: SpanContext) => Set(
+    LogAnnotation("myTraceId", Show[TraceId].show(spanContext.traceId)),
+    LogAnnotation("mySpanId", Show[SpanId].show(spanContext.spanId))
+  )
+)
+
+// Disable log enrichment entirely
+val noEnrichmentLayer: URLayer[ZEntryPoint, ZTracer] = ZTracer.layerWith(LogContextExtractor.none)
+```

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
@@ -1,12 +1,11 @@
 package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka
 
-import cats.syntax.show.*
 import cats.syntax.foldable.*
 import fs2.kafka.{ConsumerRecord, Headers}
 import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, SpanRelationship, ZSpan, ZTracer}
 import trace4cats.ToHeaders
 import trace4cats.model.{AttributeValue, Link, SpanKind, TraceHeaders}
-import zio.{RIO, ZIO, ZIOAspect}
+import zio.{LogAnnotation, RIO, ZIO}
 
 object KafkaConsumerTracer {
 
@@ -36,7 +35,10 @@ object KafkaConsumerTracer {
   def processSpannedConsumerRecord[R, K, V, Out](
     tracer: ZTracer,
     spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V],
-    spanRelationship: SpanRelationship = SpanRelationship.ParentChild
+    spanRelationship: SpanRelationship = SpanRelationship.ParentChild,
+    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
+      LogAnnotation(k, v.toString())
+    }.toSet
   )(process: (ConsumerRecord[K, V], ZSpan) => RIO[R, Out]): ConsumerRecord[K, V] => RIO[R, Out] = {
     (record: ConsumerRecord[K, V]) =>
       val traceHeaders = extractTraceHeaders(record.headers)
@@ -62,7 +64,10 @@ object KafkaConsumerTracer {
 
       def body(span: ZSpan): RIO[R, Out] = {
         val addLink = producerLink.fold(ZIO.unit)(span.addLink)
-        addLink *> span.putAll(attributes) *> process(record, span)
+        addLink *> span.putAll(attributes) *>
+          ZIO.logAnnotate(logAnnotationsFromAttributes(attributes))(
+            process(record, span)
+          )
       }
 
       val traced = spanRelationship match {
@@ -72,15 +77,20 @@ object KafkaConsumerTracer {
           tracer.withSpan(name = spanName, kind = SpanKind.Consumer)(body)
       }
 
-      traced @@ ZIOAspect.annotated(attributes.view.mapValues(_.show).toSeq*)
+      traced
   }
 
   def processConsumerRecord[R, K, V, Out](
     tracer: ZTracer,
     spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V],
-    spanRelationship: SpanRelationship = SpanRelationship.ParentChild
+    spanRelationship: SpanRelationship = SpanRelationship.ParentChild,
+    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
+      LogAnnotation(k, v.toString())
+    }.toSet
   )(process: ConsumerRecord[K, V] => RIO[R, Out]): ConsumerRecord[K, V] => RIO[R, Out] =
-    processSpannedConsumerRecord(tracer, spanNamer, spanRelationship)((record, _) => process(record))
+    processSpannedConsumerRecord(tracer, spanNamer, spanRelationship, logAnnotationsFromAttributes)((record, _) =>
+      process(record)
+    )
 
   private def extractTraceHeaders(in: Headers): TraceHeaders =
     in.toChain.foldMap(header => TraceHeaders.of(header.key() -> header.as[String]))

--- a/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
+++ b/fs2-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/KafkaConsumerTracer.scala
@@ -2,10 +2,10 @@ package io.kaizensolutions.trace4cats.zio.extras.fs2.kafka
 
 import cats.syntax.foldable.*
 import fs2.kafka.{ConsumerRecord, Headers}
-import io.kaizensolutions.trace4cats.zio.extras.{OtelSemconv, SpanRelationship, ZSpan, ZTracer}
+import io.kaizensolutions.trace4cats.zio.extras.{KafkaLogAnnotations, OtelSemconv, SpanRelationship, ZSpan, ZTracer}
 import trace4cats.ToHeaders
 import trace4cats.model.{AttributeValue, Link, SpanKind, TraceHeaders}
-import zio.{LogAnnotation, RIO, ZIO}
+import zio.{RIO, ZIO}
 
 object KafkaConsumerTracer {
 
@@ -36,9 +36,7 @@ object KafkaConsumerTracer {
     tracer: ZTracer,
     spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V],
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild,
-    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
-      LogAnnotation(k, v.toString())
-    }.toSet
+    kafkaLogAnnotations: KafkaLogAnnotations = KafkaLogAnnotations.default
   )(process: (ConsumerRecord[K, V], ZSpan) => RIO[R, Out]): ConsumerRecord[K, V] => RIO[R, Out] = {
     (record: ConsumerRecord[K, V]) =>
       val traceHeaders = extractTraceHeaders(record.headers)
@@ -65,7 +63,7 @@ object KafkaConsumerTracer {
       def body(span: ZSpan): RIO[R, Out] = {
         val addLink = producerLink.fold(ZIO.unit)(span.addLink)
         addLink *> span.putAll(attributes) *>
-          ZIO.logAnnotate(logAnnotationsFromAttributes(attributes))(
+          ZIO.logAnnotate(kafkaLogAnnotations(attributes))(
             process(record, span)
           )
       }
@@ -84,11 +82,9 @@ object KafkaConsumerTracer {
     tracer: ZTracer,
     spanNamer: SpanNamer[K, V] = SpanNamer.default[K, V],
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild,
-    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
-      LogAnnotation(k, v.toString())
-    }.toSet
+    kafkaLogAnnotations: KafkaLogAnnotations = KafkaLogAnnotations.default
   )(process: ConsumerRecord[K, V] => RIO[R, Out]): ConsumerRecord[K, V] => RIO[R, Out] =
-    processSpannedConsumerRecord(tracer, spanNamer, spanRelationship, logAnnotationsFromAttributes)((record, _) =>
+    processSpannedConsumerRecord(tracer, spanNamer, spanRelationship, kafkaLogAnnotations)((record, _) =>
       process(record)
     )
 

--- a/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
+++ b/fs2-kafka/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/fs2/kafka/Fs2KafkaTracedSpec.scala
@@ -89,15 +89,17 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
             tracer   <- ZIO.service[ZTracer]
             producer <- ZIO.service[Producer]
             consumer <- ZIO.service[Consumer]
-            p        <- Promise.make[Nothing, Unit]
+            p        <- Promise.make[Nothing, Map[String, String]]
             _        <- consumer.subscribeTo(topic)
             _ <- consumer
-                   .consumeChunkTraced(tracer, spanRelationship = SpanRelationship.ParentChild)(_ => p.succeed(()).unit)
+                   .consumeChunkTraced(tracer, spanRelationship = SpanRelationship.ParentChild)(_ =>
+                     p.complete(ZIO.logAnnotations).unit
+                   )
                    .forkScoped
 
-            _     <- producer.produceOne(topic, "key", "value")
-            _     <- p.await
-            spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"process $topic")))
+            _           <- producer.produceOne(topic, "key", "value")
+            annotations <- p.await
+            spans       <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"process $topic")))
           } yield assertTrue(
             // Consumer span shares the same trace ID as producer span (parent-child)
             spans.exists(consumerSpan =>
@@ -106,7 +108,9 @@ object Fs2KafkaTracedSpec extends ZIOSpecDefault {
                 spans.exists(producerSpan =>
                   producerSpan.kind == SpanKind.Producer &&
                     consumerSpan.context.traceId.show == producerSpan.context.traceId.show
-                )
+                ) &&
+                annotations.get("trace_id").contains(consumerSpan.context.traceId.show) &&
+                annotations.get("span_id").contains(consumerSpan.context.spanId.show)
             ),
             // Link is still added
             spans.exists(consumerSpan =>

--- a/sttp/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp/SttpBackendTracer.scala
+++ b/sttp/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp/SttpBackendTracer.scala
@@ -9,7 +9,7 @@ import sttp.monad.MonadError
 import trace4cats.ToHeaders
 import trace4cats.model.*
 import trace4cats.model.AttributeValue.{LongValue, StringValue}
-import zio.{Task, ZIOAspect}
+import zio.Task
 
 // Lifted from io.janstenpickle.trace4cats.sttp.client3 to remain semantically the same
 object SttpBackendTracer {
@@ -19,8 +19,7 @@ object SttpBackendTracer {
     toHeaders: ToHeaders = ToHeaders.standard,
     spanNamer: Request[?, ?] => String = methodWithPathSpanNamer,
     dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
-    extractResponseAttributes: Response[?] => Map[String, AttributeValue] = _ => Map.empty,
-    enrichLogs: Boolean = true
+    extractResponseAttributes: Response[?] => Map[String, AttributeValue] = _ => Map.empty
   ): SttpBackend[Task, Capabilities] = new SttpBackend[Task, Capabilities] {
     override def send[T, R >: Capabilities & Effect[Task]](request: Request[T, R]): Task[Response[T]] = {
       val nameOfRequest = spanNamer(request)
@@ -39,10 +38,6 @@ object SttpBackendTracer {
         val reqExtraAttrs: Map[String, AttributeValue] =
           if (isSampled) toAttributes(request)
           else Map.empty
-
-        val logTraceContext =
-          if (enrichLogs) ZIOAspect.annotated(traceHeaders.values.map { case (k, v) => k.toString -> v }.toSeq*)
-          else ZIOAspect.identity
 
         val tracedRequest =
           for {
@@ -71,7 +66,7 @@ object SttpBackendTracer {
                 "error.cause"         -> AttributeValue.StringValue(cause.prettyPrint)
               )
               .when(cause.isDie && isSampled)
-          ) @@ logTraceContext
+          )
       }
     }
 
@@ -80,10 +75,10 @@ object SttpBackendTracer {
     override def responseMonad: MonadError[Task] = new RIOMonadAsyncError[Any]
   }
 
-  def methodWithPathSpanNamer(req: Request[?, ?]): String =
+  private def methodWithPathSpanNamer(req: Request[?, ?]): String =
     s"${req.method.method} ${req.uri.pathSegments.toString}"
 
-  def convertTraceHeaders(in: TraceHeaders): Headers =
+  private def convertTraceHeaders(in: TraceHeaders): Headers =
     Headers(in.values.map { case (k, v) => Header(k.toString, v) }.toList)
 
   private def toSpanStatus(body: String, statusCode: StatusCode): SpanStatus = (body, statusCode) match {

--- a/sttp4/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp4/BackendTracer.scala
+++ b/sttp4/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/sttp4/BackendTracer.scala
@@ -9,7 +9,7 @@ import sttp.monad.MonadError
 import trace4cats.ToHeaders
 import trace4cats.model.*
 import trace4cats.model.AttributeValue.{LongValue, StringValue}
-import zio.{Task, ZIOAspect}
+import zio.Task
 
 // Lifted from io.janstenpickle.trace4cats.sttp.client4 to remain semantically the same
 object BackendTracer {
@@ -19,8 +19,7 @@ object BackendTracer {
     toHeaders: ToHeaders = ToHeaders.standard,
     spanNamer: GenericRequest[?, Effect[Task]] => String = methodWithPathSpanNamer,
     dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
-    extractResponseAttributes: Response[?] => Map[String, AttributeValue] = _ => Map.empty,
-    enrichLogs: Boolean = true
+    extractResponseAttributes: Response[?] => Map[String, AttributeValue] = _ => Map.empty
   ): Backend[Task] = new Backend[Task] {
     override def send[T](request: GenericRequest[T, Any with Effect[Task]]): Task[Response[T]] = {
       val nameOfRequest = spanNamer(request)
@@ -41,10 +40,6 @@ object BackendTracer {
         val reqExtraAttrs: Map[String, AttributeValue] =
           if (isSampled) toAttributes(request)
           else Map.empty
-
-        val logTraceContext =
-          if (enrichLogs) ZIOAspect.annotated(traceHeaders.values.map { case (k, v) => k.toString -> v }.toSeq*)
-          else ZIOAspect.identity
 
         val tracedRequest =
           for {
@@ -73,7 +68,7 @@ object BackendTracer {
                 "error.cause"         -> AttributeValue.StringValue(cause.prettyPrint)
               )
               .when(cause.isDie && isSampled)
-          ) @@ logTraceContext
+          )
       }
     }
 

--- a/tapir/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptor.scala
+++ b/tapir/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptor.scala
@@ -24,8 +24,6 @@ import zio.*
  *   trace
  * @param enrichResponseHeadersWithTraceIds
  *   whether to add trace headers to the response
- * @param enrichLogs
- *   whether to add trace headers to the logs
  * @param headerFormat
  *   the format to use for trace headers
  */
@@ -33,7 +31,6 @@ final class TraceInterceptor[Env, Err] private (
   private val tracer: ZTracer,
   private val dropHeadersWhen: String => Boolean,
   private val enrichResponseHeadersWithTraceIds: Boolean,
-  private val enrichLogs: Boolean,
   private val headerFormat: ToHeaders
 ) extends RequestInterceptor[ZIO[Env, Err, *]] {
 
@@ -45,7 +42,6 @@ final class TraceInterceptor[Env, Err] private (
       tracer,
       dropHeadersWhen,
       enrichResponseHeadersWithTraceIds,
-      enrichLogs,
       headerFormat
     )
 
@@ -60,13 +56,11 @@ object TraceInterceptor {
     tracer: ZTracer,
     dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
     enrichResponseHeadersWithTraceIds: Boolean = true,
-    enrichLogs: Boolean = true,
     headerFormat: ToHeaders = ToHeaders.standard
   ): TraceInterceptor[Env, Err] = new TraceInterceptor(
     tracer,
     dropHeadersWhen,
     enrichResponseHeadersWithTraceIds,
-    enrichLogs,
     headerFormat
   )
 
@@ -74,26 +68,23 @@ object TraceInterceptor {
     tracer: ZTracer,
     dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
     enrichResponseHeadersWithTraceIds: Boolean = true,
-    enrichLogs: Boolean = true,
     headerFormat: ToHeaders = ToHeaders.standard
   ): TraceInterceptor[Any, Throwable] =
-    apply(tracer, dropHeadersWhen, enrichResponseHeadersWithTraceIds, enrichLogs, headerFormat)
+    apply(tracer, dropHeadersWhen, enrichResponseHeadersWithTraceIds, headerFormat)
 
   def rio[R, E <: Throwable](
     tracer: ZTracer,
     dropHeadersWhen: String => Boolean = HeaderNames.isSensitive,
     enrichResponseHeadersWithTraceIds: Boolean = true,
-    enrichLogs: Boolean = true,
     headerFormat: ToHeaders = ToHeaders.standard
   ): TraceInterceptor[R, E] =
-    apply(tracer, dropHeadersWhen, enrichResponseHeadersWithTraceIds, enrichLogs, headerFormat)
+    apply(tracer, dropHeadersWhen, enrichResponseHeadersWithTraceIds, headerFormat)
 }
 
 private class TraceEndpointInterceptor[Env, Err](
   private val tracer: ZTracer,
   private val dropHeadersWhen: String => Boolean,
   private val enrichResponseHeadersWithTraceIds: Boolean,
-  private val enrichLogs: Boolean,
   private val headerFormat: ToHeaders
 ) extends EndpointInterceptor[ZIO[Env, Err, *]] {
   override def apply[B](
@@ -155,14 +146,10 @@ private class TraceEndpointInterceptor[Env, Err](
       val traceHeaders = TraceHeaders.of(request.headers.map(h => (h.name, h.value))*)
 
       tracer.fromHeaders(traceHeaders, name = spanName, kind = SpanKind.Server) { span =>
-        val logTraceContext =
-          if (enrichLogs) ZIOAspect.annotated(annotations = extractKVHeaders(span, headerFormat).toList*)
-          else ZIOAspect.identity
-
         for {
           _ <- span.put(OtelSemconv.HttpRoute, ctx.endpoint.showPathTemplate(showQueryParam = None))
           _ <- enrichSpanFromRequest(request, dropHeadersWhen, span)
-          response <- (zio @@ logTraceContext)
+          response <- zio
                         .tapErrorCause(cause => span.setStatus(SpanStatus.Internal(cause.prettyPrint)))
           enriched <- EnrichSpanFromResponse[A].apply(response, span)
         } yield enriched
@@ -176,12 +163,6 @@ private class TraceEndpointInterceptor[Env, Err](
       .values
       .collect { case (k, v) if v.nonEmpty => Header(k.toString, v) }
       .toSeq
-
-  private def extractKVHeaders(span: ZSpan, whichHeaders: ToHeaders): Map[String, String] =
-    span
-      .extractHeaders(whichHeaders)
-      .values
-      .collect { case (k, v) if v.nonEmpty => (k.toString, v) }
 
   private def enrichSpanFromRequest(
     request: ServerRequest,

--- a/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptorSpec.scala
+++ b/tapir/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/tapir/TraceInterceptorSpec.scala
@@ -11,6 +11,7 @@ import trace4cats.{ToHeaders, TraceProcess}
 import zio.interop.catz.*
 import zio.test.*
 import zio.{Cause, Scope, Task, ZIO}
+import cats.syntax.show.*
 
 object TraceInterceptorSpec extends ZIOSpecDefault {
 
@@ -61,7 +62,14 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
         spans.flatMap(_.attributes.get("http.response.status_code")).exists(_.value.value == 200),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
-            e.annotations.contains("traceparent")
+            e.annotations
+              .get("trace_id")
+              .zip(e.annotations.get("span_id"))
+              .zip(spans.find(_.name == "GET /hello/{name}/greeting"))
+              .exists { case ((traceId, spanId), span) =>
+                span.context.traceId.show == traceId &&
+                span.context.spanId.show == spanId
+              }
         )
       )
     },
@@ -91,7 +99,14 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
         spans.flatMap(_.attributes.get("http.response.status_code")).exists(_.value.value == 400),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
-            e.annotations.contains("traceparent")
+            e.annotations
+              .get("trace_id")
+              .zip(e.annotations.get("span_id"))
+              .zip(spans.find(_.name == "GET /hello/{name}/greeting"))
+              .exists { case ((traceId, spanId), span) =>
+                span.context.traceId.show == traceId &&
+                span.context.spanId.show == spanId
+              }
         )
       )
     },
@@ -121,7 +136,14 @@ object TraceInterceptorSpec extends ZIOSpecDefault {
         spans.flatMap(_.attributes.get("http.response.status_code")).exists(_.value.value == 401),
         logs.exists(e =>
           e.message().startsWith("Request: GET /hello/cal/greeting") &&
-            e.annotations.contains("traceparent")
+            e.annotations
+              .get("trace_id")
+              .zip(e.annotations.get("span_id"))
+              .zip(spans.find(_.name == "GET /hello/{name}/greeting"))
+              .exists { case ((traceId, spanId), span) =>
+                span.context.traceId.show == traceId &&
+                span.context.spanId.show == spanId
+              }
         )
       )
     }

--- a/zio-http-examples/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/examples/ExampleServerApp.scala
+++ b/zio-http-examples/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/examples/ExampleServerApp.scala
@@ -37,7 +37,7 @@ object ExampleServerApp extends ZIOAppDefault {
 
   override val run: ZIO[ZIOAppArgs & Scope, Any, Any] =
     Server
-      .serve(app @@ trace(enrichLogs = true))
+      .serve(app @@ trace())
       .provide(
         Server.default,
         JaegerEntrypoint.live,

--- a/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/server/ZioHttpServerTracer.scala
+++ b/zio-http/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/server/ZioHttpServerTracer.scala
@@ -20,17 +20,11 @@ object ZioHttpServerTracer {
    *   you have path parameters
    * @param errorHandler
    *   is used to handle errors
-   * @param enrichLogs
-   *   whether to enrich logs with trace information
-   * @param logHeaders
-   *   which headers to log
    * @return
    */
   def trace(
     dropHeadersWhen: String => Boolean = SensitiveHeaders.contains,
-    errorHandler: ErrorHandler = ErrorHandler.empty,
-    enrichLogs: Boolean = false,
-    logHeaders: ToHeaders = ToHeaders.standard
+    errorHandler: ErrorHandler = ErrorHandler.empty
   ): Middleware[ZTracer] = new Middleware[ZTracer] {
     override def apply[Env <: ZTracer, Err](routes: Routes[Env, Err]): Routes[Env, Err] =
       Routes.fromIterable(
@@ -43,16 +37,12 @@ object ZioHttpServerTracer {
 
                 ZIO.serviceWithZIO[ZTracer](
                   _.fromHeaders(traceHeaders, nameOfSpan, SpanKind.Server, errorHandler) { span =>
-                    val logTraceContext =
-                      if (enrichLogs) ZIOAspect.annotated(annotations = extractKVHeaders(span, logHeaders).toList*)
-                      else ZIOAspect.identity
-
                     enrichSpanFromRequest(request, dropHeadersWhen, span) *>
                       span
                         .put(OtelSemconv.HttpRoute, AttributeValue.StringValue(route.routePattern.pathCodec.render))
                         .when(span.isSampled) *>
                       // NOTE: We need to call handler.runZIO and have the code executed within our span for propagation to take place
-                      (h.runZIO(request) @@ logTraceContext).onExit {
+                      h.runZIO(request).onExit {
                         case Exit.Success(response) => enrichSpanFromResponse(response, dropHeadersWhen, span)
                         case Exit.Failure(cause)    => span.setStatus(SpanStatus.Internal(cause.prettyPrint))
                       }
@@ -99,12 +89,6 @@ object ZioHttpServerTracer {
         .values
         .collect { case (k, v) if v.nonEmpty => Header.Custom(k.toString, v) }
     )
-
-  private def extractKVHeaders(span: ZSpan, whichHeaders: ToHeaders): Map[String, String] =
-    span
-      .extractHeaders(whichHeaders)
-      .values
-      .collect { case (k, v) if v.nonEmpty => (k.toString, v) }
 
   private def enrichSpanFromRequest(request: Request, dropHeadersWhen: String => Boolean, span: ZSpan): UIO[Unit] = {
     val reqFields = requestFields(request, dropHeadersWhen)

--- a/zio-http/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/ZioHttpServerTracerSpec.scala
+++ b/zio-http/src/test/scala/io/kaizensolutions/trace4cats/zio/extras/ziohttp/ZioHttpServerTracerSpec.scala
@@ -1,5 +1,6 @@
 package io.kaizensolutions.trace4cats.zio.extras.ziohttp
 
+import cats.syntax.show.*
 import io.kaizensolutions.trace4cats.zio.extras.ziohttp.server.ZioHttpServerTracer
 import io.kaizensolutions.trace4cats.zio.extras.{InMemorySpanCompleter, OtelSemconv, ZTracer}
 import trace4cats.model.CompletedSpan
@@ -14,14 +15,15 @@ object ZioHttpServerTracerSpec extends ZIOSpecDefault {
     Routes(
       Method.GET / "plaintext" -> handler(
         ZTracer.withSpan("plaintext-fetch") { _ =>
-          Random
-            .nextIntBetween(1, 3)
-            .map(sleep =>
-              Response
-                .text(sleep.toString)
-                .updateHeaders(_.addHeader(customHeaderName, sleep.toString))
-                .status(Status.Ok)
-            )
+          ZIO.log("server") *>
+            Random
+              .nextIntBetween(1, 3)
+              .map(sleep =>
+                Response
+                  .text(sleep.toString)
+                  .updateHeaders(_.addHeader(customHeaderName, sleep.toString))
+                  .status(Status.Ok)
+              )
         }
       ),
       Method.GET / "user" / string("userId") -> handler((userId: String, _: Request) =>
@@ -50,11 +52,16 @@ object ZioHttpServerTracerSpec extends ZIOSpecDefault {
             spanIdOfHttp         = httpSpan.context.spanId
             // This is done because assertTrue gets confused response.status and response.status(...)
             responseStatus = response.status
+            logs          <- ZTestLogger.logOutput
           } yield assertTrue(
             responseStatus == Status.Ok,
             spans.length == 2,
             httpSpan.attributes.contains(s"http.response.header.${customHeaderName.toLowerCase}"),
-            parentSpanIdOfFetch == spanIdOfHttp
+            parentSpanIdOfFetch == spanIdOfHttp,
+            logs.exists(entry =>
+              entry.annotations.get("trace_id").contains(fetchSpan.context.traceId.show) &&
+                entry.annotations.get("span_id").contains(fetchSpan.context.spanId.show)
+            )
           )
         } +
           test("spans with path parameters have reduced cardinality automatically") {

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
@@ -20,9 +20,7 @@ object KafkaConsumerTracer {
     tracer: ZTracer,
     stream: ZStream[R, Throwable, CommittableRecord[K, V]],
     spanNameForElement: SpanNamer[K, V] = SpanNamer.default[K, V],
-    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
-      LogAnnotation(k, v.toString())
-    }.toSet,
+    kafkaLogAnnotations: KafkaLogAnnotations = KafkaLogAnnotations.default,
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   ): ZStream[R, Throwable, Spanned[CommittableRecord[K, V]]] =
     stream.mapChunksZIO(_.mapZIO { comm =>
@@ -33,19 +31,18 @@ object KafkaConsumerTracer {
 
       val attributes = coreAttributes(topic, record.partition, comm.offset.offset, Option(record.key).map(_.toString))
 
-      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, logAnnotationsFromAttributes) {
-        span =>
-          val enrichedComm = comm.copy(
-            commitHandle = _ =>
-              tracer.fromHeaders(
-                headers = ToHeaders.standard.fromContext(span.context),
-                name = s"commit $topic",
-                kind = SpanKind.Client
-              ) { commitSpan =>
-                commitSpan.putAll(attributes) *> comm.offset.commit
-              }
-          )
-          ZIO.succeed(Spanned(span.extractHeaders(ToHeaders.all), enrichedComm))
+      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, kafkaLogAnnotations) { span =>
+        val enrichedComm = comm.copy(
+          commitHandle = _ =>
+            tracer.fromHeaders(
+              headers = ToHeaders.standard.fromContext(span.context),
+              name = s"commit $topic",
+              kind = SpanKind.Client
+            ) { commitSpan =>
+              commitSpan.putAll(attributes) *> comm.offset.commit
+            }
+        )
+        ZIO.succeed(Spanned(span.extractHeaders(ToHeaders.all), enrichedComm))
       }
     })
 
@@ -56,9 +53,7 @@ object KafkaConsumerTracer {
     keyDeserializer: Deserializer[R, K],
     valueDeserializer: Deserializer[R, V],
     commitRetryPolicy: Schedule[Any, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3),
-    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
-      LogAnnotation(k, v.toString())
-    }.toSet,
+    kafkaLogAnnotations: KafkaLogAnnotations = KafkaLogAnnotations.default,
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   )(f: KafkaConsumerRecord[K, V] => URIO[R1, Unit]): RIO[R & R1, Unit] =
     consumer.consumeWith[R, R1, K, V](subscription, keyDeserializer, valueDeserializer, commitRetryPolicy) {
@@ -72,8 +67,8 @@ object KafkaConsumerTracer {
           Option(consumerRecord.key).map(_.toString)
         )
 
-        withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, logAnnotationsFromAttributes) {
-          _ => f(consumerRecord)
+        withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, kafkaLogAnnotations) { _ =>
+          f(consumerRecord)
         }
     }
 
@@ -100,7 +95,7 @@ object KafkaConsumerTracer {
     spanName: String,
     spanRelationship: SpanRelationship,
     attributes: Map[String, AttributeValue],
-    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation]
+    kafkaLogAnnotations: KafkaLogAnnotations
   )(body: ZSpan => ZIO[R, Nothing, A]): ZIO[R, Nothing, A] = {
     val producerLink =
       ToHeaders.standard.toContext(traceHeaders).map(ctx => trace4cats.model.Link(ctx.traceId, ctx.spanId))
@@ -108,7 +103,7 @@ object KafkaConsumerTracer {
     def run(span: ZSpan): ZIO[R, Nothing, A] = {
       val addLink = producerLink.fold(ZIO.unit)(span.addLink)
       addLink *> span.putAll(attributes) *>
-        ZIO.logAnnotate(logAnnotationsFromAttributes(attributes))(
+        ZIO.logAnnotate(kafkaLogAnnotations(attributes))(
           body(span)
         )
     }

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
@@ -1,14 +1,14 @@
 package io.kaizensolutions.trace4cats.zio.extras.ziokafka
 
 import io.kaizensolutions.trace4cats.zio.extras.*
+import izumi.reflect.Tag
+import org.apache.kafka.clients.consumer.ConsumerRecord as KafkaConsumerRecord
 import trace4cats.model.AttributeValue
 import trace4cats.{SpanKind, ToHeaders}
+import zio.*
 import zio.kafka.consumer.*
-import org.apache.kafka.clients.consumer.ConsumerRecord as KafkaConsumerRecord
 import zio.kafka.serde.Deserializer
 import zio.stream.ZStream
-import izumi.reflect.Tag
-import zio.*
 
 object KafkaConsumerTracer {
   type SpanNamer[K, V] = CommittableRecord[K, V] => String
@@ -20,7 +20,9 @@ object KafkaConsumerTracer {
     tracer: ZTracer,
     stream: ZStream[R, Throwable, CommittableRecord[K, V]],
     spanNameForElement: SpanNamer[K, V] = SpanNamer.default[K, V],
-    enrichLogs: Boolean = true,
+    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
+      LogAnnotation(k, v.toString())
+    }.toSet,
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   ): ZStream[R, Throwable, Spanned[CommittableRecord[K, V]]] =
     stream.mapChunksZIO(_.mapZIO { comm =>
@@ -31,18 +33,19 @@ object KafkaConsumerTracer {
 
       val attributes = coreAttributes(topic, record.partition, comm.offset.offset, Option(record.key).map(_.toString))
 
-      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes) { span =>
-        val enrichedComm = comm.copy(
-          commitHandle = _ =>
-            tracer.fromHeaders(
-              headers = ToHeaders.standard.fromContext(span.context),
-              name = s"commit $topic",
-              kind = SpanKind.Client
-            ) { commitSpan =>
-              commitSpan.putAll(attributes) *> comm.offset.commit
-            }
-        )
-        ZIO.succeed(Spanned(span.extractHeaders(ToHeaders.all), enrichedComm, enrichLogs))
+      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, logAnnotationsFromAttributes) {
+        span =>
+          val enrichedComm = comm.copy(
+            commitHandle = _ =>
+              tracer.fromHeaders(
+                headers = ToHeaders.standard.fromContext(span.context),
+                name = s"commit $topic",
+                kind = SpanKind.Client
+              ) { commitSpan =>
+                commitSpan.putAll(attributes) *> comm.offset.commit
+              }
+          )
+          ZIO.succeed(Spanned(span.extractHeaders(ToHeaders.all), enrichedComm))
       }
     })
 
@@ -53,7 +56,9 @@ object KafkaConsumerTracer {
     keyDeserializer: Deserializer[R, K],
     valueDeserializer: Deserializer[R, V],
     commitRetryPolicy: Schedule[Any, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3),
-    enrichLogs: Boolean = true,
+    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
+      LogAnnotation(k, v.toString())
+    }.toSet,
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   )(f: KafkaConsumerRecord[K, V] => URIO[R1, Unit]): RIO[R & R1, Unit] =
     consumer.consumeWith[R, R1, K, V](subscription, keyDeserializer, valueDeserializer, commitRetryPolicy) {
@@ -67,12 +72,8 @@ object KafkaConsumerTracer {
           Option(consumerRecord.key).map(_.toString)
         )
 
-        val logAspect =
-          if (enrichLogs) ZIOAspect.annotated(attributes.map { case (k, v) => (k, v.toString) }.toSeq*)
-          else ZIOAspect.identity
-
-        withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes) { _ =>
-          f(consumerRecord) @@ logAspect
+        withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, logAnnotationsFromAttributes) {
+          _ => f(consumerRecord)
         }
     }
 
@@ -98,14 +99,18 @@ object KafkaConsumerTracer {
     traceHeaders: trace4cats.model.TraceHeaders,
     spanName: String,
     spanRelationship: SpanRelationship,
-    attributes: Map[String, AttributeValue]
+    attributes: Map[String, AttributeValue],
+    logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation]
   )(body: ZSpan => ZIO[R, Nothing, A]): ZIO[R, Nothing, A] = {
     val producerLink =
       ToHeaders.standard.toContext(traceHeaders).map(ctx => trace4cats.model.Link(ctx.traceId, ctx.spanId))
 
     def run(span: ZSpan): ZIO[R, Nothing, A] = {
       val addLink = producerLink.fold(ZIO.unit)(span.addLink)
-      addLink *> span.putAll(attributes) *> body(span)
+      addLink *> span.putAll(attributes) *>
+        ZIO.logAnnotate(logAnnotationsFromAttributes(attributes))(
+          body(span)
+        )
     }
 
     spanRelationship match {

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/KafkaConsumerTracer.scala
@@ -16,11 +16,28 @@ object KafkaConsumerTracer {
     def default[K, V]: SpanNamer[K, V] = record => s"process ${record.record.topic}"
   }
 
+  /**
+   * Wraps a ZIO Kafka consumer stream with tracing. Each record is consumed
+   * within a span whose context is derived from the record's headers (if
+   * present). The resulting stream emits [[Spanned]] records so that downstream
+   * operators can continue the trace.
+   *
+   * Commits are also traced under a child span of the consumer span.
+   *
+   * @param tracer
+   *   the ZTracer instance
+   * @param stream
+   *   the source stream of committable records
+   * @param spanNameForElement
+   *   derives the span name from each record (default: "process {topic}")
+   * @param spanRelationship
+   *   controls whether the consumer span is a child of the producer span
+   *   (ParentChild) or starts a new trace with a link (Link)
+   */
   def traceConsumerStream[R, K, V](
     tracer: ZTracer,
     stream: ZStream[R, Throwable, CommittableRecord[K, V]],
     spanNameForElement: SpanNamer[K, V] = SpanNamer.default[K, V],
-    kafkaLogAnnotations: KafkaLogAnnotations = KafkaLogAnnotations.default,
     spanRelationship: SpanRelationship = SpanRelationship.ParentChild
   ): ZStream[R, Throwable, Spanned[CommittableRecord[K, V]]] =
     stream.mapChunksZIO(_.mapZIO { comm =>
@@ -31,7 +48,8 @@ object KafkaConsumerTracer {
 
       val attributes = coreAttributes(topic, record.partition, comm.offset.offset, Option(record.key).map(_.toString))
 
-      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, kafkaLogAnnotations) { span =>
+      // Because there are no logs inside the consumer span, there is no meaning to kafka log annotations here
+      withConsumerSpan(tracer, traceHeaders, spanName, spanRelationship, attributes, KafkaLogAnnotations.none) { span =>
         val enrichedComm = comm.copy(
           commitHandle = _ =>
             tracer.fromHeaders(
@@ -46,6 +64,33 @@ object KafkaConsumerTracer {
       }
     })
 
+  /**
+   * Consumes records from a Kafka subscription with automatic tracing and
+   * offset commits. Each record is processed within a traced span. This is a
+   * convenience method that combines consumption, tracing, and committing in
+   * one call using ZIO Kafka's `consumeWith` under the hood.
+   *
+   * @param tracer
+   *   the ZTracer instance
+   * @param consumer
+   *   the ZIO Kafka consumer
+   * @param subscription
+   *   the topic subscription
+   * @param keyDeserializer
+   *   deserializer for record keys
+   * @param valueDeserializer
+   *   deserializer for record values
+   * @param commitRetryPolicy
+   *   retry policy for offset commits
+   * @param kafkaLogAnnotations
+   *   controls which span attributes are surfaced as ZIO log annotations
+   *   (default: topic, partition, offset, key)
+   * @param spanRelationship
+   *   controls whether the consumer span is a child of the producer span
+   *   (ParentChild) or starts a new trace with a link (Link)
+   * @param f
+   *   the processing function for each record
+   */
   def tracedConsumeWith[R: Tag, R1: Tag, K, V](
     tracer: ZTracer,
     consumer: Consumer,

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/package.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/package.scala
@@ -19,9 +19,7 @@ package object ziokafka {
       keyDeserializer: Deserializer[R, K],
       valueDeserializer: Deserializer[R, V],
       commitRetryPolicy: Schedule[Any, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3),
-      logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
-        LogAnnotation(k, v.toString())
-      }.toSet,
+      kafkaLogAnnotations: KafkaLogAnnotations = KafkaLogAnnotations.default,
       spanRelationship: SpanRelationship = SpanRelationship.ParentChild
     )(f: KafkaConsumerRecord[K, V] => URIO[R1, Unit]): RIO[R & R1 & ZTracer, Unit] =
       ZIO.serviceWithZIO[ZTracer] { tracer =>
@@ -32,7 +30,7 @@ package object ziokafka {
           keyDeserializer,
           valueDeserializer,
           commitRetryPolicy,
-          logAnnotationsFromAttributes,
+          kafkaLogAnnotations,
           spanRelationship
         )(f)
       }

--- a/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/package.scala
+++ b/zio-kafka/src/main/scala/io/kaizensolutions/trace4cats/zio/extras/ziokafka/package.scala
@@ -19,7 +19,9 @@ package object ziokafka {
       keyDeserializer: Deserializer[R, K],
       valueDeserializer: Deserializer[R, V],
       commitRetryPolicy: Schedule[Any, Any, Any] = Schedule.exponential(1.second) && Schedule.recurs(3),
-      enrichLogs: Boolean = true,
+      logAnnotationsFromAttributes: Map[String, AttributeValue] => Set[LogAnnotation] = _.map { case (k, v) =>
+        LogAnnotation(k, v.toString())
+      }.toSet,
       spanRelationship: SpanRelationship = SpanRelationship.ParentChild
     )(f: KafkaConsumerRecord[K, V] => URIO[R1, Unit]): RIO[R & R1 & ZTracer, Unit] =
       ZIO.serviceWithZIO[ZTracer] { tracer =>
@@ -30,7 +32,7 @@ package object ziokafka {
           keyDeserializer,
           valueDeserializer,
           commitRetryPolicy,
-          enrichLogs,
+          logAnnotationsFromAttributes,
           spanRelationship
         )(f)
       }

--- a/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
+++ b/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
@@ -74,7 +74,7 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
         val topic = UUID.randomUUID().toString
         for {
           tracer   <- ZIO.service[ZTracer]
-          p        <- Promise.make[Nothing, Unit]
+          p        <- Promise.make[Nothing, Map[String, String]]
           consumer <- ZIO.service[Consumer]
           producer <- ZIO.service[Producer]
           _ <- KafkaConsumerTracer
@@ -83,15 +83,17 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
                    consumer.plainStream(Subscription.topics(topic), Serde.string, Serde.string),
                    spanRelationship = SpanRelationship.ParentChild
                  )
+                 .tapWithTracer(tracer, "internal") { _ =>
+                   p.complete(ZIO.logAnnotations)
+                 }
                  .endTracingEachElement
                  .tap(_.offset.commit)
-                 .tap(_ => p.succeed(()))
                  .runDrain
                  .forkScoped
 
-          _     <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
-          _     <- p.await
-          spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"commit $topic")))
+          _           <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
+          annotations <- p.await
+          spans       <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.awaitCollected(_.exists(_.name == s"commit $topic")))
         } yield assertTrue(
           // Consumer span shares the same trace ID as producer span (parent-child)
           spans.exists(consumerSpan =>
@@ -99,8 +101,18 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
               spans.exists(producerSpan =>
                 producerSpan.kind == SpanKind.Producer &&
                   consumerSpan.context.traceId.show == producerSpan.context.traceId.show
-              )
+              ) &&
+              consumerSpan.attributes.contains(OtelSemconv.MessagingKafkaOffset)
           ),
+          spans
+            .find(_.name == "internal")
+            .zip(annotations.get("trace_id"))
+            .zip(annotations.get("span_id"))
+            .exists { case ((span, traceId), spanId) =>
+              span.context.spanId.show == spanId &&
+              span.context.traceId.show == traceId
+            },
+
           // Link is still added
           spans.exists(consumerSpan =>
             consumerSpan.name == s"process $topic" &&

--- a/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
+++ b/zio-kafka/src/test/scala/ZioKafkaTracedSpec.scala
@@ -174,7 +174,7 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
         val topic = UUID.randomUUID().toString
         for {
           tracer   <- ZIO.service[ZTracer]
-          p        <- Promise.make[Nothing, Unit]
+          p        <- Promise.make[Nothing, Map[String, String]]
           consumer <- ZIO.service[Consumer]
           producer <- ZIO.service[Producer]
           fiber <-
@@ -186,12 +186,12 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
                 Serde.string,
                 Serde.string,
                 spanRelationship = SpanRelationship.ParentChild
-              )(_ => p.succeed(()).unit)
+              )(_ => p.complete(ZIO.logAnnotations).unit)
               .forkScoped
-          _     <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
-          _     <- p.await
-          _     <- fiber.interrupt
-          spans <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.retrieveCollected)
+          _           <- producer.produce(topic, "key", "value", Serde.string, Serde.string)
+          annotations <- p.await
+          _           <- fiber.interrupt
+          spans       <- ZIO.serviceWithZIO[InMemorySpanCompleter](_.retrieveCollected)
         } yield assertTrue(
           // Consumer span shares the same trace ID as producer span
           spans.exists(consumerSpan =>
@@ -199,7 +199,9 @@ object ZioKafkaTracedSpec extends ZIOSpecDefault {
               spans.exists(producerSpan =>
                 producerSpan.kind == SpanKind.Producer &&
                   consumerSpan.context.traceId.show == producerSpan.context.traceId.show
-              )
+              ) &&
+              annotations.get("trace_id").contains(consumerSpan.context.traceId.show) &&
+              annotations.get("span_id").contains(consumerSpan.context.spanId.show)
           ),
           // Link is still added
           spans.exists(consumerSpan =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable log-context enrichment for ZIO logs, including OpenTelemetry-compatible `trace_id` and `span_id` annotations.
  * Added options for custom annotations or disabling log enrichment.
  * Kafka tracing now supports configurable span-attribute log annotations.

* **Documentation**
  * Updated integration examples and guidance for configuring log-context enrichment.

* **Refactor**
  * Simplified tracing integrations by removing legacy log-enrichment options and standardizing configuration through tracer setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->